### PR TITLE
3.2.165: refactor filters store module [WTEL-3774]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webitel/ui-sdk",
-  "version": "3.2.164",
+  "version": "3.2.165",
   "private": false,
   "scripts": {
     "serve-lib": "vue-cli-service serve",


### PR DESCRIPTION
3.2.165: refactor filters store module [WTEL-3774]

Refactor the FiltersStoreModule.js file in the src/modules/Filters/store directory. Significant changes include:
- Added a new constant SET_FILTER_SOURCE to define different sources for setting filters.
- Implemented getters GET_FILTER and GET_FILTERS to retrieve specific filter values and all filter values respectively.
- Implemented getter GET_VALUE_FROM_QUERY to get the value of a filter from the query string using a query key.
- Modified the SET_FILTER action to handle multiple values, default values, and different sources for setting filters.
- Modified the CHANGE_ROUTE_QUERY action to update the route query based on filter changes.
- Added new actions RESTORE_FILTER and RESTORE_FILTERS to restore individual filters and all filters respectively.
- Modified the RESET_FILTERS action to reset all filters by dispatching SET_FILTER with default values for each filter.
- Updated ON_FILTER_SET action to debounce loading data list after a filter is set.

These changes aim to improve the functionality and maintainability of the FiltersStoreModule in order to enhance filtering capabilities within the application.