### PR TITLE
[WTEL-7349][https://webitel.atlassian.net/browse/WTEL-7349] fixed ope…

### DIFF
--- a/src/components/wt-button-select/wt-button-select.vue
+++ b/src/components/wt-button-select/wt-button-select.vue
@@ -20,14 +20,14 @@
       :tooltip-triggers="[]"
       @click="selectOption"
     >
-      <template #activator>
+      <template #activator="{ toggle, show }">
         <wt-button
           :color="color"
           :disabled="disabled"
           :loading="false"
           class="wt-button-select__select-btn"
           v-bind="$attrs"
-          @click="isOpened = !isOpened"
+          @click="toggleContextMenu(toggle, $event)"
         >
           <wt-icon
             :class="{ 'wt-button-select__select-arrow--active': isOpened }"
@@ -92,6 +92,11 @@ const selectOption = ({ option, index }) => {
 
 const atClickaway = () => {
   isOpened.value = false;
+};
+
+const toggleContextMenu = (toggle, e) => {
+  isOpened.value = !isOpened.value;
+  toggle(e)
 };
 </script>
 


### PR DESCRIPTION


## Description
isOpened prop was passed for opening and closing, but the popover in the context menu was opened only through the functions passed in the slots

## Related Tasks

* [WT-XXXX]()
[WTEL-7349][https://webitel.atlassian.net/browse/WTEL-7349]

## Related PR's / Issues

* 

## Todos
fixed open context menu for button select
- [ ] Implementation
- [ ] Documentation


[WTEL-7349]: https://webitel.atlassian.net/browse/WTEL-7349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ