### PR TITLE
[WTEL-5794][https://webitel.atlassian.net/browse/WTEL-5794] fixed clo…

### DIFF
--- a/src/components/wt-datepicker/wt-datepicker.vue
+++ b/src/components/wt-datepicker/wt-datepicker.vue
@@ -85,6 +85,8 @@
 
 <script setup>
 import '@vuepic/vue-datepicker/dist/main.css';
+import { useWindowFocus } from '@vueuse/core'
+import { watch } from 'vue'
 
 import VueDatepicker from '@vuepic/vue-datepicker';
 import { computed, ref, toRefs } from 'vue';
@@ -161,6 +163,8 @@ const emit = defineEmits(['input']);
 const isOpened = ref(false);
 const datepicker = ref(null); // template ref
 
+const winFocused = useWindowFocus()
+
 const isDateTime = props.mode === 'datetime';
 
 const requiredLabel = computed(() => {
@@ -178,12 +182,23 @@ const { isValidation, invalid, validationText } = useValidation({
 const clearValue = () => {
   emit('input', null);
 
+  closePicker()
+};
+
+const closePicker = () => {
   if (isOpened.value) {
     datepicker?.value.closeMenu();
   }
 
   isOpened.value = false;
-};
+}
+
+// close picker when window loses focus(when clicking to iframe)
+// https://webitel.atlassian.net/browse/WTEL-5794
+watch(winFocused, (focused) => {
+  if (!focused && isOpened.value) closePicker()
+})
+
 </script>
 
 <style lang="scss">


### PR DESCRIPTION

## Description
when the datapicker is opened and we click on the iframe, it does not catch that we clicked on the document, also onClickOutside was triggered from the 2nd time, so it did not work
## Related Tasks

* [WTEL-5794][https://webitel.atlassian.net/browse/WTEL-5794] 

## Related PR's / Issues

* 

## Todos
Fixed close datapicker when click in iframe
- [ ] Implementation
- [ ] Documentation


[WTEL-5794]: https://webitel.atlassian.net/browse/WTEL-5794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ