### PR TITLE
fix: explicit label prop for wt-type-extension-value-input [WTEL-9394](https://webitel.atlassian.net/browse/WTEL-9394)

### DIFF
--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_custom/type-extension-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_custom/type-extension-filter-value-field.vue
@@ -3,6 +3,7 @@
     v-bind="attrs"
     v-model:model-value="model"
     :field="props.filterConfig.field"
+    :required="false"
   >
     <template #[WtTypeExtensionFieldKind.Boolean]="{ defaultProps }">
       <has-option-filter-value-field v-model:model-value="model" />

--- a/src/components/on-demand/wt-type-extension-value-input/wt-type-extension-value-input.vue
+++ b/src/components/on-demand/wt-type-extension-value-input/wt-type-extension-value-input.vue
@@ -26,19 +26,19 @@
     v-else-if="field.kind === FieldType.Select"
     :name="FieldType.Select"
     :default-props="{
-        ...sharedChildrenProps,
-        ...selectProps,
-        value,
-      }"
+      ...sharedChildrenProps,
+      ...selectProps,
+      value,
+    }"
   >
-  <wt-select
-    v-bind="sharedChildrenProps"
-    :value="value"
-    :search-method="loadLookupList(field.lookup)"
-    track-by="id"
-    clearable
-    @input="selectElement"
-  />
+    <wt-select
+      v-bind="sharedChildrenProps"
+      :value="value"
+      :search-method="loadLookupList(field.lookup)"
+      track-by="id"
+      clearable
+      @input="selectElement"
+    />
   </slot>
   <slot
     v-else-if="field.kind === FieldType.Multiselect"
@@ -85,6 +85,7 @@ const model = defineModel<unknown>();
 
 const props = defineProps<{
 	field: WebitelProtoDataField;
+	label?: string;
 	required?: boolean;
 	/**
 	 * TODO: implement validation
@@ -95,11 +96,11 @@ const props = defineProps<{
 const { t } = useI18n();
 
 const label = computed(() => {
-	return t(props.field?.name || 'vocabulary.labels');
+	return props.label || t(props.field?.name || 'vocabulary.labels');
 });
 
 const isRequired = computed(() => {
-	return props.required || props.field.required;
+	return props.required ?? props.field.required;
 });
 
 const value = computed(() => {


### PR DESCRIPTION
Проблема:
У формі фільтрів для різних типів полів відображався різний лейбл.
 - для текстових і числових полів показувався правильний підпис  - “Значення”
 - для випадаючих списків - підпис брався з назви самого поля (що виглядало неузгоджено)

Причина
Один із компонентів wt-type-extension-value-input, який відповідає за відображення поля, не мав явного параметра для лейблу.

Що зроблено
Явно додана можливість передавати лейбл у цей компонент.

Тепер логіка така:
 - якщо підпис переданий — використовується він
 - якщо ні - береться назва поля

!!! Але мене турбує slot який обгортає Select. Чи задумувалось з самого початку що лейбл селекту має мати назву кастомного поля ? Чи те що пропс label не був переданий у wt-type-extension-value-input - це випадковість ?

--------------------------------------------------------------------------------------------------------------------------------------------------

--- UPD ---

Тут проблема була  в тому, що пропс label не був явно переданий у компонент.
 
Через це компонент фолбеком-ом використовував імʼя кастомного поля як label. Мене це заплутало, бо спочатку виглядало так, ніби для select/multiselect навмисно задумана логіка: label = name.
 
Додатково збило з пантелику те, що батьківський компонент деструктуризував пропси дочірнього компонента і передавав їх далі в компонент, який рендериться замість слота. Через це було складніше зрозуміти, де саме формується фінальний label.
 
 Ще мене підзапутало те “чому пропси дочірнього компонента піднімаються і перепаковуються на рівні батька”. У React подібний підхід зазвичай вважається поганою практикою, бо робить потік даних менш очевидним. І я там завис трошки))
 
Через комбінацію цих двох речей я сприйняв це як спеціально закладену поведінку, хоча фактично проблема була в тому, що label просто не був явно переданий.
 
От такі от пироги ))
