### PR TITLE
fix: add title attribute to video element in chat-message-player [WTEL-9345]

### DIFF
--- a/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-player.vue
+++ b/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-player.vue
@@ -7,6 +7,7 @@
       v-if="isVideo"
       :size="ComponentSize.SM"
       :src="mediaSrc"
+      :title="file.name"
       static
       hide-expand
       stretch


### PR DESCRIPTION
 (https://webitel.atlassian.net/browse/WTEL-9345)

## Description

## Related Tasks

* [WT-XXXX]()

## Related PR's / Issues

* 

## Todos

- [ ] Implementation
- [ ] Documentation
