### PR TITLE
Fix/wtel 9394/validation trigger

### DIFF
--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_custom/type-extension-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_custom/type-extension-filter-value-field.vue
@@ -7,7 +7,7 @@
     :v="v$.model"
   >
     <template #[WtTypeExtensionFieldKind.Boolean]="{ defaultProps }">
-      <has-option-filter-value-field v-model:model-value="model"/>
+      <has-option-filter-value-field v-bind="defaultProps" v-model:model-value="model"/>
     </template>
     <template #[WtTypeExtensionFieldKind.Select]="{ defaultProps }">
       <wt-select
@@ -35,6 +35,7 @@
         "
         use-value-from-options-by-prop="id"
         @input="model = $event"
+        :v="v$.model"
       />
     </template>
     <template #[WtTypeExtensionFieldKind.Calendar]>
@@ -84,8 +85,6 @@ const v$ = useVuelidate(
 		$autoDirty: true,
 	},
 );
-
-v$.value.$touch();
 
 watch(
 	() => v$.value.$invalid,

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_custom/type-extension-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_custom/type-extension-filter-value-field.vue
@@ -35,7 +35,6 @@
         "
         use-value-from-options-by-prop="id"
         @input="model = $event"
-        :v="v$.model"
       />
     </template>
     <template #[WtTypeExtensionFieldKind.Calendar]>

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_custom/type-extension-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_custom/type-extension-filter-value-field.vue
@@ -4,9 +4,10 @@
     v-model:model-value="model"
     :field="props.filterConfig.field"
     :required="false"
+    :v="v$.model"
   >
     <template #[WtTypeExtensionFieldKind.Boolean]="{ defaultProps }">
-      <has-option-filter-value-field v-model:model-value="model" />
+      <has-option-filter-value-field v-model:model-value="model"/>
     </template>
     <template #[WtTypeExtensionFieldKind.Select]="{ defaultProps }">
       <wt-select
@@ -83,6 +84,8 @@ const v$ = useVuelidate(
 		$autoDirty: true,
 	},
 );
+
+v$.value.$touch();
 
 watch(
 	() => v$.value.$invalid,

--- a/src/components/on-demand/wt-type-extension-value-input/wt-type-extension-value-input.vue
+++ b/src/components/on-demand/wt-type-extension-value-input/wt-type-extension-value-input.vue
@@ -93,6 +93,8 @@ const props = defineProps<{
 	v?: object;
 }>();
 
+props.v?.$touch();
+
 const { t } = useI18n();
 
 const label = computed(() => {


### PR DESCRIPTION
Проблема:
Об'єкт валідації не сетився у компонент який рендирить кастомні фільтри (wt-type-extension-value-input).
В кастомний WtTypeExtensionFieldKind.Boolean  (has-option-filter-value-field)-  не потрапляв пропс defaultProps який в собі містив об'єкт валідації  v$.model.

Фікс:
Явно передав v$.model у необхідні компоненти.
Тригернути валідацю при маунті компонента. 
