### PR TITLE
fix:create useMediaScroll composable and add it to the-message-container.vue for scrolling images [WTEL-8208]

### DIFF
--- a/packages/ui-chats/src/ui/index.ts
+++ b/packages/ui-chats/src/ui/index.ts
@@ -1,4 +1,5 @@
 export { ChatAction } from './chat-footer/modules/user-input/enums/ChatAction.enum';
+export { useMediaScroll } from './messaging/composables/useMediaScroll';
 export { useChatMessageFile } from './messaging/modules/message/composables/useChatMessageFile';
 export { MessageAction } from './messaging/modules/message/enums/MessageAction.enum';
 export type {

--- a/packages/ui-chats/src/ui/messaging/components/the-messages-container.vue
+++ b/packages/ui-chats/src/ui/messaging/components/the-messages-container.vue
@@ -57,6 +57,7 @@ import {
 import { ChatAction } from '../../chat-footer/modules/user-input/enums/ChatAction.enum';
 import type { UiChatsEmitterEvents } from '../../utils/emitter';
 import { useChatScroll } from '../composables/useChatScroll';
+import { useMediaScroll } from '../composables/useMediaScroll';
 import ChatMessage from '../modules/message/components/chat-message.vue';
 import { useChatMessages } from '../modules/message/composables/useChatMessage';
 import { MessageAction } from '../modules/message/enums/MessageAction.enum';
@@ -103,6 +104,10 @@ const {
 	computed(() => props.isLoading),
 );
 
+const { startObserving } = useMediaScroll(messagesContainer, () =>
+	scrollToBottom('smooth'),
+);
+
 function handleLoadNextMessages() {
 	loadNextMessages(props.next, () => emit(ChatAction.LoadNextMessages));
 }
@@ -121,6 +126,7 @@ onMounted(async () => {
 	setTimeout(() => {
 		scrollToBottom();
 	}, 500);
+	startObserving();
 });
 </script>
 

--- a/packages/ui-chats/src/ui/messaging/composables/useMediaScroll.ts
+++ b/packages/ui-chats/src/ui/messaging/composables/useMediaScroll.ts
@@ -1,0 +1,55 @@
+import { onUnmounted, type Ref } from 'vue';
+
+export const useMediaScroll = (
+	element: Ref<HTMLElement | null>,
+	onMediaLoaded: () => void,
+) => {
+	let observer: MutationObserver | null = null;
+
+	const handleImageLoad = () => {
+		onMediaLoaded();
+	};
+
+	const observeImages = (img: HTMLImageElement) => {
+		if (img.complete) return;
+		img.addEventListener('load', handleImageLoad, {
+			once: true,
+		});
+	};
+
+	const startObserving = () => {
+		if (!element.value) return;
+
+		element.value.querySelectorAll('img').forEach(observeImages);
+
+		observer = new MutationObserver((mutations) => {
+			mutations.forEach((mutation) => {
+				mutation.addedNodes.forEach((node) => {
+					if (node instanceof HTMLImageElement) {
+						observeImages(node);
+					}
+					if (node instanceof HTMLElement) {
+						node.querySelectorAll('img').forEach(observeImages);
+					}
+				});
+			});
+		});
+
+		observer.observe(element.value, {
+			childList: true,
+			subtree: true,
+		});
+	};
+
+	const stopObserving = () => {
+		observer?.disconnect();
+		observer = null;
+	};
+
+	onUnmounted(stopObserving);
+
+	return {
+		startObserving,
+		stopObserving,
+	};
+};

--- a/packages/ui-chats/src/ui/messaging/composables/useMediaScroll.ts
+++ b/packages/ui-chats/src/ui/messaging/composables/useMediaScroll.ts
@@ -6,13 +6,9 @@ export const useMediaScroll = (
 ) => {
 	let observer: MutationObserver | null = null;
 
-	const handleImageLoad = () => {
-		onMediaLoaded();
-	};
-
 	const observeImages = (img: HTMLImageElement) => {
 		if (img.complete) return;
-		img.addEventListener('load', handleImageLoad, {
+		img.addEventListener('load', () => onMediaLoaded(), {
 			once: true,
 		});
 	};


### PR DESCRIPTION
Проблема:
При завантаженні зображення в чаті скрол не опускався до кінця. useChatScroll реагував на зміну messages.length і викликав scrollToBottom в момент коли картинка ще не завантажилась і мала висоту 0. Після завантаження картинки висота контейнера збільшувалась, але скрол вже відпрацював.
Рішення:
Додано новий composable useMediaScroll який через MutationObserver стежить за появою нових img елементів в контейнері повідомлень. Після завантаження зображення (load подія) викликається scrollToBottom.