### PR TITLE
fix: race condition, phantom empty option, wrong label with optionVal…

### DIFF
--- a/src/components/_internals/composables/useSelect/useSelect.ts
+++ b/src/components/_internals/composables/useSelect/useSelect.ts
@@ -1,11 +1,12 @@
-import { useSelectOptions } from './useSelectOptions';
-import { useSelectDropdown } from './useSelectDropdown';
 import { useSelectCustomValues } from './useSelectCustomValues';
+import { useSelectDropdown } from './useSelectDropdown';
+import { useSelectOptions } from './useSelectOptions';
 
 export const useSelect = ({
 	selected,
 	options,
 	optionLabel,
+	optionValue,
 	dataKey,
 	allowCustomValues,
 	manualCustomValues = false,
@@ -31,6 +32,7 @@ export const useSelect = ({
 		selected,
 		options,
 		optionLabel,
+		optionValue,
 		dataKey,
 		allowCustomValues,
 		searchMethod,
@@ -72,6 +74,15 @@ export const useSelect = ({
 		emit,
 	});
 
+	const clearValue = () => {
+		let value: any = '';
+		if (Array.isArray(selected.value)) value = [];
+		else if (typeof selected.value === 'object' && selected.value !== null)
+			value = {};
+		selected.value = value;
+		emit('reset', value);
+	};
+
 	return {
 		isLoading,
 		isDropdownOpen,
@@ -85,5 +96,6 @@ export const useSelect = ({
 		onDropdownShow,
 		onDropdownHide,
 		onInputKeydown,
+		clearValue,
 	};
 };

--- a/src/components/_internals/composables/useSelect/useSelectOptions.ts
+++ b/src/components/_internals/composables/useSelect/useSelectOptions.ts
@@ -155,28 +155,31 @@ export const useSelectOptions = ({
 		}
 	};
 
+	const addSelectedValueToList = (newVal) => {
+		// If the selected value is not in the list, add it
+		if (!newVal || !searchMethod.value) return;
+		const selectedAsArray = toArray(newVal);
+		const missingSelected = selectedAsArray.filter(
+			(s) => !isOptionSelected(s, filteredOptions.value, dataKey.value),
+		);
+		if (missingSelected.length) {
+			filteredOptions.value = sortOptions(
+				dedupeByKey(
+					[
+						...missingSelected,
+						...filteredOptions.value,
+					],
+					dataKey.value,
+				),
+			);
+		}
+	};
+
 	watch(
 		() => selected.value,
 		(newVal) => {
 			updateSelectedOptionsCache();
-
-			// If the selected value is not in the list, add it
-			if (!newVal || !searchMethod.value) return;
-			const selectedAsArray = toArray(newVal);
-			const missingSelected = selectedAsArray.filter(
-				(s) => !isOptionSelected(s, filteredOptions.value, dataKey.value),
-			);
-			if (missingSelected.length) {
-				filteredOptions.value = sortOptions(
-					dedupeByKey(
-						[
-							...missingSelected,
-							...filteredOptions.value,
-						],
-						dataKey.value,
-					),
-				);
-			}
+			addSelectedValueToList(newVal);
 		},
 	);
 

--- a/src/components/_internals/composables/useSelect/useSelectOptions.ts
+++ b/src/components/_internals/composables/useSelect/useSelectOptions.ts
@@ -1,14 +1,13 @@
-import { useI18n } from 'vue-i18n';
 import { reactive, ref, watch } from 'vue';
-import deepEqual from 'deep-equal';
-import uniqWith from 'lodash/uniqWith';
+import { useI18n } from 'vue-i18n';
 import debounce from '../../../../scripts/debounce';
-import { toArray, isOptionSelected } from './useSelectUtils';
+import { dedupeByKey, isOptionSelected, toArray } from './useSelectUtils';
 
 export const useSelectOptions = ({
 	selected,
 	options,
 	optionLabel,
+	optionValue,
 	dataKey,
 	allowCustomValues,
 	searchMethod,
@@ -30,7 +29,7 @@ export const useSelectOptions = ({
 	  selected values that are not in the list are prepended as-is
 	*/
 	const sortOptions = (opts) => {
-		const deduped = uniqWith(opts, deepEqual);
+		const deduped = dedupeByKey(opts, dataKey.value);
 		if (!selected.value) return deduped;
 
 		const selectedAsArray = toArray(selected.value);
@@ -55,11 +54,21 @@ export const useSelectOptions = ({
 	};
 
 	const getOptionLabel = (option) => {
+		if (!option) return '';
 		// https://webitel.atlassian.net/browse/WTEL-3181
 		// if allowCustomValue select mode, return label as is
 		if (allowCustomValues.value && option.isTag) return option.label;
 
-		if (optionLabel && option[optionLabel]) return option[optionLabel];
+		// when optionValue is used PrimeVue passes the extracted primitive instead of the full object
+		if (optionValue?.value && typeof option !== 'object') {
+			const foundOption = (
+				filteredOptions.value as Record<string, unknown>[]
+			).find((o) => o[optionValue.value] === option);
+			return foundOption ? getOptionLabel(foundOption) : String(option);
+		}
+
+		if (optionLabel.value && option[optionLabel.value])
+			return option[optionLabel.value];
 		if (option.locale) {
 			if (Array.isArray(option.locale)) return t(...option.locale);
 			return t(option.locale);
@@ -83,12 +92,12 @@ export const useSelectOptions = ({
 		// Find full option objects from filteredOptions that match selected values
 		const foundOptions = filteredOptions.value.filter(isSelected);
 		// Merge with previous cache, then remove entries no longer selected
-		const mergedOptions = uniqWith(
+		const mergedOptions = dedupeByKey(
 			[
 				...selectedOptionsCache.value,
 				...foundOptions,
 			],
-			deepEqual,
+			dataKey.value,
 		);
 		selectedOptionsCache.value = mergedOptions.filter(isSelected);
 	};
@@ -103,12 +112,13 @@ export const useSelectOptions = ({
 		});
 		const baseOptions =
 			searchParams.page === 1
-				? uniqWith(
+				? dedupeByKey(
 						[
+							...toArray(selected.value).filter(Boolean),
 							...selectedOptionsCache.value,
 							...items,
 						],
-						deepEqual,
+						dataKey.value,
 					)
 				: filteredOptions.value.concat(items);
 		filteredOptions.value = sortOptions(baseOptions);
@@ -132,12 +142,12 @@ export const useSelectOptions = ({
 				getOptionLabel(option).toLowerCase().includes(value.toLowerCase()),
 			);
 			filteredOptions.value = sortOptions(
-				uniqWith(
+				dedupeByKey(
 					[
 						...selectedOptionsCache.value,
 						...matchingOptions,
 					],
-					deepEqual,
+					dataKey.value,
 				),
 			);
 		} else {
@@ -145,9 +155,30 @@ export const useSelectOptions = ({
 		}
 	};
 
-	watch(() => selected.value, updateSelectedOptionsCache, {
-		deep: true,
-	});
+	watch(
+		() => selected.value,
+		(newVal) => {
+			updateSelectedOptionsCache();
+
+			// If the selected value is not in the list, add it
+			if (!newVal || !searchMethod.value) return;
+			const selectedAsArray = toArray(newVal);
+			const missingSelected = selectedAsArray.filter(
+				(s) => !isOptionSelected(s, filteredOptions.value, dataKey.value),
+			);
+			if (missingSelected.length) {
+				filteredOptions.value = sortOptions(
+					dedupeByKey(
+						[
+							...missingSelected,
+							...filteredOptions.value,
+						],
+						dataKey.value,
+					),
+				);
+			}
+		},
+	);
 
 	return {
 		filterText,

--- a/src/components/_internals/composables/useSelect/useSelectUtils.ts
+++ b/src/components/_internals/composables/useSelect/useSelectUtils.ts
@@ -7,6 +7,23 @@ export const toArray = (value) =>
 
 export const isOptionSelected = (option, selectedArray, dataKey) => {
 	return dataKey
-		? selectedArray.some((s) => s[dataKey] === option[dataKey])
+		? selectedArray.some((s) => s != null && s[dataKey] === option[dataKey])
 		: selectedArray.some((s) => s === option);
+};
+
+export const dedupeByKey = (items: unknown[], key: string): unknown[] => {
+	if (!key) {
+		// no dataKey — fall back to reference dedup via Set
+		return [
+			...new Set(items),
+		];
+	}
+	const seen = new Map();
+	for (const item of items) {
+		const k = (item as any)[key];
+		if (!seen.has(k)) seen.set(k, item);
+	}
+	return [
+		...seen.values(),
+	];
 };

--- a/src/components/wt-chip/wt-chip.vue
+++ b/src/components/wt-chip/wt-chip.vue
@@ -42,9 +42,9 @@ withDefaults(defineProps<WtProps>(), {
 	removable: false,
 });
 
-const emit = defineEmits([
-	'remove',
-]);
+const emit = defineEmits<{
+	(e: 'remove'): void;
+}>();
 </script>
 
 <style scoped>

--- a/src/components/wt-chip/wt-chip.vue
+++ b/src/components/wt-chip/wt-chip.vue
@@ -43,7 +43,7 @@ withDefaults(defineProps<WtProps>(), {
 });
 
 const emit = defineEmits<{
-	(e: 'remove'): void;
+	remove: [];
 }>();
 </script>
 

--- a/src/components/wt-chip/wt-chip.vue
+++ b/src/components/wt-chip/wt-chip.vue
@@ -6,7 +6,12 @@
   >
     <slot />
     <template #removeicon>
-      <wt-icon class="wt-chip__close-icon" icon="close--filled" />
+      <wt-icon-btn
+				class="wt-chip__close-icon" 
+				icon="close--filled" 
+				:size="ComponentSize.SM"
+				@click="emit('remove', $event)"
+			/>
     </template>
   </p-chip>
 </template>
@@ -14,7 +19,7 @@
 <script setup lang="ts">
 import type { ChipProps } from 'primevue/chip';
 
-import { ChipColor } from '../../enums';
+import { ChipColor, ComponentSize } from '../../enums';
 
 interface WtProps extends ChipProps {
 	/**
@@ -36,6 +41,10 @@ withDefaults(defineProps<WtProps>(), {
 	color: ChipColor.MAIN,
 	removable: false,
 });
+
+const emit = defineEmits([
+	'remove',
+]);
 </script>
 
 <style scoped>

--- a/src/components/wt-multi-select/wt-multi-select.vue
+++ b/src/components/wt-multi-select/wt-multi-select.vue
@@ -177,10 +177,10 @@ const selectId = `select-${Math.random().toString(36).slice(2, 11)}`;
 const filterInput = useTemplateRef('filterInput');
 const selectRef = useTemplateRef('selectRef');
 
-const emit = defineEmits([
-	'add:custom-value',
-	'reset',
-]);
+const emit = defineEmits<{
+	(e: 'add:custom-value', value: string): void;
+	(e: 'reset'): void;
+}>();
 
 const {
 	isLoading,

--- a/src/components/wt-multi-select/wt-multi-select.vue
+++ b/src/components/wt-multi-select/wt-multi-select.vue
@@ -178,8 +178,10 @@ const filterInput = useTemplateRef('filterInput');
 const selectRef = useTemplateRef('selectRef');
 
 const emit = defineEmits<{
-	(e: 'add:custom-value', value: string): void;
-	(e: 'reset'): void;
+	'add:custom-value': [
+		value: string,
+	];
+	reset: [];
 }>();
 
 const {

--- a/src/components/wt-multi-select/wt-multi-select.vue
+++ b/src/components/wt-multi-select/wt-multi-select.vue
@@ -65,22 +65,27 @@
           class="wt-multi-select__option-checkbox"
         />
       </template>
-      <template #clearicon="{clearCallback}">
+      <template #clearicon>
         <wt-icon-btn 
           v-if="showClear && model"  
           icon="close" 
-          @click="clearCallback"
+          @click="clearValue"
         />
       </template>
       <template #dropdownicon>
         <wt-icon :icon="isDropdownOpen ? 'arrow-up' : 'arrow-down'" />
       </template>
-      <template #chipicon="{removeCallback}">
-        <wt-icon-btn 
-          icon="close--filled" 
-          size="sm"
-          @click="removeCallback"
-        />
+      <template #loadingicon>
+        <wt-loader :size="ComponentSize.SM" />
+      </template>
+      <template #chip="{ value, removeCallback }">
+        <wt-chip
+          removable
+          :color="ChipColor.SECONDARY"
+          @remove="removeCallback($event)"
+        > 
+          {{ getOptionLabel(value) }}
+        </wt-chip>
       </template>
     </p-multi-select>
     <wt-message
@@ -95,12 +100,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, toRefs, useSlots, useTemplateRef } from 'vue';
 import type { SelectProps } from 'primevue';
-import { ComponentSize, MessageColor, MessageVariant } from '../../enums';
+import { computed, onMounted, toRefs, useSlots, useTemplateRef } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { ChipColor, ComponentSize, MessageVariant } from '../../enums';
 import { useValidation } from '../../mixins/validationMixin/useValidation';
 import { useSelect } from '../_internals/composables/useSelect/useSelect';
-import { useI18n } from 'vue-i18n';
 import { toArray } from '../_internals/composables/useSelect/useSelectUtils';
 
 interface Props extends SelectProps {
@@ -148,6 +153,7 @@ interface Props extends SelectProps {
 
 const props = withDefaults(defineProps<Props>(), {
 	filterable: true,
+	showClear: true,
 	options: () => [],
 	optionLabel: 'label',
 	dataKey: 'id',
@@ -173,6 +179,7 @@ const selectRef = useTemplateRef('selectRef');
 
 const emit = defineEmits([
 	'add:custom-value',
+	'reset',
 ]);
 
 const {
@@ -188,10 +195,12 @@ const {
 	onDropdownHide,
 	filterOptions,
 	onInputKeydown,
+	clearValue,
 } = useSelect({
 	selected: model,
 	options: computed(() => props.options),
 	optionLabel: computed(() => props.optionLabel),
+	optionValue: computed(() => props.optionValue),
 	dataKey: computed(() => props.dataKey),
 	allowCustomValues: computed(() => props.allowCustomValues),
 	manualCustomValues: computed(() => props.manualCustomValues),

--- a/src/components/wt-single-select/wt-single-select.vue
+++ b/src/components/wt-single-select/wt-single-select.vue
@@ -47,23 +47,37 @@
           </template>
         </wt-input-text>
       </template>
-      <template #option="{ option }">
-        <span
-          class="wt-single-select__option-label"
-          v-tooltip="getOptionLabel(option)"
-        >
-          {{ getOptionLabel(option) }}
-        </span>
+      <template v-if="model" #value="{ value, placeholder }">
+        <slot name="value" v-bind="{ value, getOptionLabel, placeholder }">
+          <span
+            v-tooltip="getOptionLabel(value)"
+          >
+            {{ getOptionLabel(value) || placeholder }}
+          </span>
+        </slot>
       </template>
-      <template #clearicon="{clearCallback}">
+      <template #option="{ option }">
+        <slot name="option" v-bind="{ option, getOptionLabel }">
+          <span
+            class="wt-single-select__option-label"
+            v-tooltip="getOptionLabel(option)"
+          >
+            {{ getOptionLabel(option) }}
+          </span>
+        </slot>
+      </template>
+      <template #clearicon>
         <wt-icon-btn 
           v-if="showClear && model"  
           icon="close" 
-          @click="clearCallback"
+          @click="clearValue"
         />
       </template>
       <template #dropdownicon>
         <wt-icon :icon="isDropdownOpen ? 'arrow-up' : 'arrow-down'" />
+      </template>
+      <template #loadingicon>
+        <wt-loader :size="ComponentSize.SM" />
       </template>
     </p-select>
     <wt-message
@@ -78,8 +92,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, toRefs, useSlots, useTemplateRef } from 'vue';
 import type { SelectProps } from 'primevue';
+import { computed, onMounted, toRefs, useSlots, useTemplateRef } from 'vue';
 import { ComponentSize, MessageColor, MessageVariant } from '../../enums';
 import { useValidation } from '../../mixins/validationMixin/useValidation';
 import { useSelect } from '../_internals/composables/useSelect/useSelect';
@@ -124,6 +138,7 @@ interface Props extends SelectProps {
 
 const props = withDefaults(defineProps<Props>(), {
 	filterable: true,
+	showClear: true,
 	options: () => [],
 	optionLabel: 'label',
 	dataKey: 'id',
@@ -133,7 +148,16 @@ const props = withDefaults(defineProps<Props>(), {
 
 const model = defineModel<string>({
 	default: '',
+	get: (value) => {
+		if (value == null) return '';
+		if (typeof value !== 'object') return value;
+		return Object.keys(value).length > 0 ? value : '';
+	},
 });
+
+const emit = defineEmits([
+	'reset',
+]);
 
 const selectId = `select-${Math.random().toString(36).slice(2, 11)}`;
 
@@ -153,10 +177,12 @@ const {
 	onDropdownHide,
 	filterOptions,
 	onInputKeydown,
+	clearValue,
 } = useSelect({
 	selected: model,
 	options: computed(() => props.options),
 	optionLabel: computed(() => props.optionLabel),
+	optionValue: computed(() => props.optionValue),
 	dataKey: computed(() => props.dataKey),
 	allowCustomValues: computed(() => props.allowCustomValues),
 	filterInput,
@@ -164,6 +190,7 @@ const {
 	searchMethod: computed(() => props.searchMethod),
 	selectId: computed(() => selectId),
 	isSingle: true,
+	emit,
 });
 
 const slots = useSlots();

--- a/src/components/wt-single-select/wt-single-select.vue
+++ b/src/components/wt-single-select/wt-single-select.vue
@@ -155,9 +155,9 @@ const model = defineModel<string>({
 	},
 });
 
-const emit = defineEmits([
-	'reset',
-]);
+const emit = defineEmits<{
+	(e: 'reset'): void;
+}>();
 
 const selectId = `select-${Math.random().toString(36).slice(2, 11)}`;
 

--- a/src/components/wt-single-select/wt-single-select.vue
+++ b/src/components/wt-single-select/wt-single-select.vue
@@ -156,7 +156,7 @@ const model = defineModel<string>({
 });
 
 const emit = defineEmits<{
-	(e: 'reset'): void;
+	reset: [];
 }>();
 
 const selectId = `select-${Math.random().toString(36).slice(2, 11)}`;

--- a/src/plugins/primevue/theme/components/multi-select/multi-select.js
+++ b/src/plugins/primevue/theme/components/multi-select/multi-select.js
@@ -18,6 +18,14 @@ const multiSelect = {
 			overflow: hidden;
 			text-overflow: ellipsis;
 		}
+
+		.p-multiselect-label:has(.p-chip) {
+			padding: ${dt('multiselect.paddingY')} ${dt('multiselect.paddingX')};
+		}
+
+		.p-multiselect-chip-item {
+			display: flex;
+		}
 	`,
 };
 


### PR DESCRIPTION
…ue, and chip remove crash in wt-single-select and wt-multi-select [WTEL-8147](https://webitel.atlassian.net/browse/WTEL-8147)

- Fix race condition where selected option was missing from the list
  by reading selected.value after fetch resolves instead of before
- Fix phantom empty option caused by falsy initial store state ({})
  via filter(Boolean) and a defineModel getter in wt-single-select
- Fix wrong label when optionValue prop is used by adding reverse-lookup
  in getOptionLabel for primitive values passed by PrimeVue
- Fix chip remove crash (stopPropagation on undefined) by passing
  native click event through wt-chip's remove emit
- Replace lodash/deep-equal dedup with a leaner dedupeByKey util
- Add null guard in isOptionSelected to prevent crashes on empty state
- Pass optionValue into useSelect/useSelectOptions composables


[WTEL-8147]: https://webitel.atlassian.net/browse/WTEL-8147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ