### PR TITLE
refactor(AppConfig): add reusable app config module

### DIFF
--- a/docs/.vitepress/routes/packages/ui-sdk.docs.routes.ts
+++ b/docs/.vitepress/routes/packages/ui-sdk.docs.routes.ts
@@ -79,6 +79,13 @@ export const uiSdkRoutes = [
 				text: 'Modules',
 				items: [
 					{
+						text: 'Module: App Config',
+						collapsed: true,
+						items: resolveItems([
+							'modules/AppConfig/**/*.md',
+						]),
+					},
+					{
 						text: 'Module: Object Permissions',
 						collapsed: true,
 						items: [

--- a/docs/pages/packages/ui-sdk/modules/AppConfig/index.md
+++ b/docs/pages/packages/ui-sdk/modules/AppConfig/index.md
@@ -1,0 +1,82 @@
+# `AppConfig` Module
+
+Reusable runtime app config module. Fetches a static config served next to
+the app and deep-merges it over per-app defaults.
+
+> [!IMPORTANT]
+> Config shape is **per application**. Each app supplies its own config type
+> `T` and its own `defaultConfig`. The module only provides the generic
+> fetch/merge plumbing.
+
+## TLDR Usage
+
+```ts
+// 1. Describe your app's config shape
+// types/AppConfig.ts
+export interface AppConfig {
+  token: { iss: string; endpointUrl: string; appToken: string };
+  lang: 'en' | 'uk' | 'ru';
+  // ...whatever your app needs
+}
+
+// 2. Provide defaults (PartialDeep<AppConfig>)
+// defaults/defaultConfig.ts
+import type { PartialDeep } from '@webitel/ui-sdk/modules/AppConfig';
+import type { AppConfig } from '../types/AppConfig';
+
+export const defaultConfig: PartialDeep<AppConfig> = {
+  lang: 'en',
+};
+
+// 3. Build the module
+// config.ts
+import { createAppConfig } from '@webitel/ui-sdk/modules/AppConfig';
+import { defaultConfig } from './defaults/defaultConfig';
+import type { AppConfig } from './types/AppConfig';
+
+export const { getConfig, initializeConfig } =
+  createAppConfig<AppConfig>(defaultConfig);
+```
+
+```ts
+// usage
+import { getConfig, initializeConfig } from './config';
+
+// on app bootstrap — fetch + resolve once
+const config = await initializeConfig();
+
+// anywhere else — returns cached config, initializing on first access
+const $config = await getConfig();
+```
+
+## How config is resolved
+
+`createAppConfig` deep-merges the fetched runtime config **over** your
+`defaultConfig`. The runtime config is loaded by `fetchConfig`, which looks for
+files served next to the app, local file winning:
+
+| Priority | File                                |
+|----------|-------------------------------------|
+| 1 (low)  | `config.json` / `config.jsonc`      |
+| 2 (high) | `config.local.json` / `config.local.jsonc` |
+
+`.jsonc` (JSON with comments) is supported via `tiny-jsonc`.
+
+> [!NOTE]
+> Arrays in config **overwrite** (source wins) rather than concatenate, so a
+> fetched array fully replaces the default one.
+
+## API
+
+### `createAppConfig<T>(defaultConfig): AppConfigModule<T>`
+
+Returns `{ getConfig, initializeConfig }`.
+
+- `initializeConfig(): Promise<T>` — fetch + resolve, replacing the cached value.
+- `getConfig(): Promise<T>` — return the cached config, calling
+  `initializeConfig` on first access.
+
+### `fetchConfig<T>(): Promise<Partial<T>>`
+
+Low-level helper that just fetches and merges the static config files. Exposed
+for apps that need the raw fetched config without the default-merge step.

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,7 @@
 				"lodash-es": "^4.17.21",
 				"mitt": "^3.0.1",
 				"path-browserify": "^1.0.1",
+				"tiny-jsonc": "^1.0.2",
 				"vidstack": "^1.12.13",
 				"vue-i18n": "^11.1.2",
 				"vue-router": "^4.5.0",
@@ -12658,6 +12659,13 @@
 			"integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/tiny-jsonc": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tiny-jsonc/-/tiny-jsonc-1.0.2.tgz",
+			"integrity": "sha512-f5QDAfLq6zIVSyCZQZhhyl0QS6MvAyTxgz4X4x3+EoCktNWEYJ6PeoEA97fyb98njpBNNi88ybpD7m+BDFXaCw==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"lodash-es": "^4.17.21",
 		"mitt": "^3.0.1",
 		"path-browserify": "^1.0.1",
+		"tiny-jsonc": "^1.0.2",
 		"vidstack": "^1.12.13",
 		"vue-i18n": "^11.1.2",
 		"vue-router": "^4.5.0",
@@ -319,6 +320,10 @@
 		"./src/modules*": {
 			"types": "./types/modules*",
 			"import": "./src/modules*"
+		},
+		"./modules/AppConfig": {
+			"types": "./types/modules/AppConfig/index.d.ts",
+			"import": "./src/modules/AppConfig/index.ts"
 		},
 		"./modules/Flow": {
 			"types": "./types/modules/Flow/index.d.ts",

--- a/src/modules/AppConfig/index.ts
+++ b/src/modules/AppConfig/index.ts
@@ -1,0 +1,63 @@
+import deepmerge from 'deepmerge';
+import type { PartialDeep } from 'type-fest';
+
+import { fetchConfig } from './scripts/fetchConfig';
+
+// Config values overwrite, they don't accumulate — let the source array win.
+const overwriteArrays = (_destination: unknown[], source: unknown[]) => source;
+
+export interface AppConfigModule<T> {
+	/**
+	 * Returns the resolved config, initializing it on first access.
+	 */
+	getConfig: () => Promise<T>;
+	/**
+	 * Fetches and resolves the config, replacing any previously cached value.
+	 */
+	initializeConfig: () => Promise<T>;
+}
+
+/**
+ * Creates a reusable app config module.
+ *
+ * Each application provides its own config type `T` and a `defaultConfig` used
+ * as the base. The fetched runtime config (see {@link fetchConfig}) is deep-merged
+ * over the defaults.
+ *
+ * @example
+ * ```ts
+ * import { createAppConfig } from '@webitel/ui-sdk/modules/AppConfig';
+ * import { defaultConfig } from './defaults/defaultConfig';
+ * import type { AppConfig } from './types/AppConfig';
+ *
+ * export const { getConfig, initializeConfig } = createAppConfig<AppConfig>(defaultConfig);
+ * ```
+ */
+export function createAppConfig<T>(
+	defaultConfig: PartialDeep<T>,
+): AppConfigModule<T> {
+	let config: T;
+
+	async function initializeConfig(): Promise<T> {
+		const fetchedConfig = await fetchConfig<T>();
+		config = deepmerge<Partial<T>>(defaultConfig as Partial<T>, fetchedConfig, {
+			arrayMerge: overwriteArrays,
+		}) as T;
+		return config;
+	}
+
+	async function getConfig(): Promise<T> {
+		if (!config) {
+			config = await initializeConfig();
+		}
+		return config;
+	}
+
+	return {
+		getConfig,
+		initializeConfig,
+	};
+}
+
+export { fetchConfig };
+export type { PartialDeep };

--- a/src/modules/AppConfig/scripts/fetchConfig.ts
+++ b/src/modules/AppConfig/scripts/fetchConfig.ts
@@ -1,0 +1,43 @@
+import deepmerge from 'deepmerge';
+import jsoncParser from 'tiny-jsonc';
+
+// Config values overwrite, they don't accumulate — let the source array win.
+const overwriteArrays = (_destination: unknown[], source: unknown[]) => source;
+
+/**
+ * Fetches the application runtime config from static files served next to the app.
+ *
+ * Looks up `config.{json,jsonc}` and an optional `config.local.{json,jsonc}` overlay,
+ * with the local file taking priority. The shape of the returned object is
+ * application-specific, so the concrete type is provided by the caller.
+ */
+export async function fetchConfig<T>(): Promise<Partial<T>> {
+	return await fetchWithLocalConfigPriority<T>();
+}
+
+async function fetchWithLocalConfigPriority<T>(): Promise<Partial<T>> {
+	const localConfig = await fetchSupportedExtConfig('config.local');
+	const config = await fetchSupportedExtConfig('config');
+
+	return deepmerge(config ?? {}, localConfig ?? {}, {
+		arrayMerge: overwriteArrays,
+	}) as Partial<T>;
+}
+
+async function fetchSupportedExtConfig(fileName = 'config') {
+	const supportedExtensions = [
+		'.json',
+		'.jsonc',
+	];
+
+	for (const extension of supportedExtensions) {
+		try {
+			const response = await fetch(`./${fileName}${extension}`);
+			if (response.ok) {
+				const configText = await response.text();
+				return jsoncParser.parse(configText);
+			}
+		} catch {}
+	}
+	return null;
+}


### PR DESCRIPTION
Extracts the app config fetch/merge logic from web-meeting into a generic, per-app-typed module. Each app supplies its own config type and defaults; createAppConfig deep-merges fetched runtime config (config + config.local, json/jsonc) over the defaults.

Adds the tiny-jsonc dependency and a ./modules/AppConfig export entry.

## Description

## Related Tasks

* [WT-XXXX]()

## Related PR's / Issues

* 

## Todos

- [ ] Implementation
- [ ] Documentation
