### PR TITLE
fix: wt-card min width [WTEL-9852](https://webitel.atlassian.net/browse/WTEL-9852)

### DIFF
--- a/src/components/wt-card/wt-card.vue
+++ b/src/components/wt-card/wt-card.vue
@@ -6,6 +6,7 @@
 
 <style lang="scss" scoped>
 .wt-card {
+  min-width: 0;
   border-radius: var(--wt-card-border-radius);
   padding: var(--wt-card-padding);
   box-shadow: var(--elevation-5);


### PR DESCRIPTION
Коли елемент стоїть усередині grid (або flex), браузер за замовчуванням вважає що елемент всередині не можна стискати вужче, ніж потрібно його вмісту. Це прихований min-width: auto.  Фікс превентить зайві розтягнення елементів які будуть розташовані у wt-card

## Description


## Related Tasks

* [WT-XXXX]()

## Related PR's / Issues

* 

## Todos

- [ ] Implementation
- [ ] Documentation
