### PR TITLE
ci: typecheck only changed packages [WTEL-9942]

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -101,10 +101,11 @@ jobs:
         with:
           node-version-file: package.json
           cache: npm
-      # Root: path aliases + shared types (e.g. vidstack). Package: own lockfile deps.
-      - run: npm ci
+      # Package first (own lockfile), then root (path aliases / shared libs).
+      # Reverse order: package workspace install can disrupt root node_modules.
       - run: npm ci
         working-directory: packages/ui-datalist
+      - run: npm ci
       - run: npm run --prefix packages/ui-datalist typecheck
 
   typecheck-ui-chats:
@@ -120,6 +121,6 @@ jobs:
           node-version-file: package.json
           cache: npm
       - run: npm ci
-      - run: npm ci
         working-directory: packages/ui-chats
+      - run: npm ci
       - run: npm run --prefix packages/ui-chats typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -101,9 +101,8 @@ jobs:
         with:
           node-version-file: package.json
           cache: npm
-      # ui-datalist is not an npm workspace — own lockfile
+      # Root install provides path aliases + shared types (e.g. vidstack)
       - run: npm ci
-        working-directory: packages/ui-datalist
       - run: npm run --prefix packages/ui-datalist typecheck
 
   typecheck-ui-chats:
@@ -118,7 +117,5 @@ jobs:
         with:
           node-version-file: package.json
           cache: npm
-      # ui-chats is not an npm workspace — own lockfile
       - run: npm ci
-        working-directory: packages/ui-chats
       - run: npm run --prefix packages/ui-chats typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -14,26 +14,39 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      root: ${{ steps.filter.outputs.root }}
+      api_services: ${{ steps.filter.outputs.api_services }}
+      styleguide: ${{ steps.filter.outputs.styleguide }}
+      ui_datalist: ${{ steps.filter.outputs.ui_datalist }}
+      ui_chats: ${{ steps.filter.outputs.ui_chats }}
+      shared: ${{ steps.filter.outputs.shared }}
     steps:
       - uses: actions/checkout@v4
       - id: filter
         uses: dorny/paths-filter@v3
         with:
           filters: |
-            code:
+            root:
               - "src/**"
               - "docs/pages/**"
-              - "packages/**"
+            api_services:
+              - "packages/api-services/**"
+            styleguide:
+              - "packages/styleguide/**"
+            ui_datalist:
+              - "packages/ui-datalist/**"
+            ui_chats:
+              - "packages/ui-chats/**"
+            shared:
               - "package.json"
               - "package-lock.json"
               - "tsconfig*.json"
               - "env.d.ts"
               - ".github/workflows/**"
 
-  typecheck:
+  typecheck-root:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.root == 'true' || needs.changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -43,11 +56,69 @@ jobs:
         with:
           node-version-file: package.json
           cache: npm
-      # ui-datalist and ui-chats are not npm workspaces — they carry their own
-      # lockfiles, and the repo-wide typecheck needs their dependencies too
-      - run: npm ci
-        working-directory: packages/ui-datalist
-      - run: npm ci
-        working-directory: packages/ui-chats
       - run: npm ci
       - run: npm run typecheck:ci
+
+  typecheck-api-services:
+    needs: changes
+    if: needs.changes.outputs.api_services == 'true' || needs.changes.outputs.shared == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+      - run: npm ci
+      - run: npm run --prefix packages/api-services typecheck
+
+  typecheck-styleguide:
+    needs: changes
+    if: needs.changes.outputs.styleguide == 'true' || needs.changes.outputs.shared == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+      - run: npm ci
+      - run: npm run --prefix packages/styleguide typecheck
+
+  typecheck-ui-datalist:
+    needs: changes
+    if: needs.changes.outputs.ui_datalist == 'true' || needs.changes.outputs.shared == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+      # ui-datalist is not an npm workspace — own lockfile
+      - run: npm ci
+        working-directory: packages/ui-datalist
+      - run: npm run --prefix packages/ui-datalist typecheck
+
+  typecheck-ui-chats:
+    needs: changes
+    if: needs.changes.outputs.ui_chats == 'true' || needs.changes.outputs.shared == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: npm
+      # ui-chats is not an npm workspace — own lockfile
+      - run: npm ci
+        working-directory: packages/ui-chats
+      - run: npm run --prefix packages/ui-chats typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -101,8 +101,10 @@ jobs:
         with:
           node-version-file: package.json
           cache: npm
-      # Root install provides path aliases + shared types (e.g. vidstack)
+      # Root: path aliases + shared types (e.g. vidstack). Package: own lockfile deps.
       - run: npm ci
+      - run: npm ci
+        working-directory: packages/ui-datalist
       - run: npm run --prefix packages/ui-datalist typecheck
 
   typecheck-ui-chats:
@@ -118,4 +120,6 @@ jobs:
           node-version-file: package.json
           cache: npm
       - run: npm ci
+      - run: npm ci
+        working-directory: packages/ui-chats
       - run: npm run --prefix packages/ui-chats typecheck

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"prepare": "husky || true",
 		"test:unit:ci": "npm run test:coverage",
 		"typecheck": "vue-tsc --noEmit -p ./tsconfig.json",
-		"typecheck:ci": "npm run typecheck"
+		"typecheck:ci": "vue-tsc --noEmit -p ./tsconfig.typecheck.json"
 	},
 	"workspaces": [
 		"./packages/api-services",

--- a/packages/api-services/package.json
+++ b/packages/api-services/package.json
@@ -20,7 +20,7 @@
 		"gen:api:typedoc": "npx typedoc",
 		"gen:api:cleanup": "rm swagger.yaml formatted-openapi.yaml",
 		"build:types": "vue-tsc -p ./tsconfig.build.json",
-		"typecheck": "vue-tsc --noEmit -p ./tsconfig.json",
+		"typecheck": "vue-tsc --noEmit -p ./tsconfig.typecheck.json",
 		"format:all": "npx biome check --write ./src",
 		"biome:ci:gh": "biome ci ./src --reporter=github",
 		"test:unit": "node -e \"process.exit(0)\"",

--- a/packages/api-services/package.json
+++ b/packages/api-services/package.json
@@ -20,6 +20,7 @@
 		"gen:api:typedoc": "npx typedoc",
 		"gen:api:cleanup": "rm swagger.yaml formatted-openapi.yaml",
 		"build:types": "vue-tsc -p ./tsconfig.build.json",
+		"typecheck": "vue-tsc --noEmit -p ./tsconfig.json",
 		"format:all": "npx biome check --write ./src",
 		"biome:ci:gh": "biome ci ./src --reporter=github",
 		"test:unit": "node -e \"process.exit(0)\"",

--- a/packages/api-services/tsconfig.typecheck.json
+++ b/packages/api-services/tsconfig.typecheck.json
@@ -1,9 +1,11 @@
 {
 	// Separate from tsconfig / tsconfig.build: needs baseUrl at repo root so
 	// monorepo path aliases resolve; must not inherit emit/rootDir from build.
+	// Clear root `types: [vidstack/vue]` — not needed for this package.
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"baseUrl": "../.."
+		"baseUrl": "../..",
+		"types": []
 	},
 	"include": [
 		"src/**/*.ts",

--- a/packages/api-services/tsconfig.typecheck.json
+++ b/packages/api-services/tsconfig.typecheck.json
@@ -1,0 +1,13 @@
+{
+	// Separate from tsconfig / tsconfig.build: needs baseUrl at repo root so
+	// monorepo path aliases resolve; must not inherit emit/rootDir from build.
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"baseUrl": "../.."
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.vue",
+		"../../env.d.ts"
+	]
+}

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -8,6 +8,7 @@
 	"scripts": {
 		"publish-styleguide": "npm run build && npm publish --access public",
 		"build": "tsc -p ./tsconfig.build.json",
+		"typecheck": "tsc --noEmit -p ./tsconfig.build.json",
 		"lint:fix": "npx biome check --write ./src",
 		"biome:ci:gh": "biome ci ./src --reporter=github",
 		"test:unit": "node -e \"process.exit(0)\"",

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"publish-styleguide": "npm run build && npm publish --access public",
 		"build": "tsc -p ./tsconfig.build.json",
-		"typecheck": "tsc --noEmit -p ./tsconfig.build.json",
+		"typecheck": "vue-tsc --noEmit -p ./tsconfig.typecheck.json",
 		"lint:fix": "npx biome check --write ./src",
 		"biome:ci:gh": "biome ci ./src --reporter=github",
 		"test:unit": "node -e \"process.exit(0)\"",

--- a/packages/styleguide/tsconfig.typecheck.json
+++ b/packages/styleguide/tsconfig.typecheck.json
@@ -1,0 +1,12 @@
+{
+	// Separate from tsconfig.build: needs baseUrl at repo root so monorepo path
+	// aliases resolve; must not inherit emit/rootDir from build.
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"baseUrl": "../.."
+	},
+	"include": [
+		"src/**/*.ts",
+		"../../env.d.ts"
+	]
+}

--- a/packages/styleguide/tsconfig.typecheck.json
+++ b/packages/styleguide/tsconfig.typecheck.json
@@ -1,9 +1,11 @@
 {
 	// Separate from tsconfig.build: needs baseUrl at repo root so monorepo path
 	// aliases resolve; must not inherit emit/rootDir from build.
+	// Clear root `types: [vidstack/vue]` — not needed for this package.
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"baseUrl": "../.."
+		"baseUrl": "../..",
+		"types": []
 	},
 	"include": [
 		"src/**/*.ts",

--- a/packages/ui-chats/package.json
+++ b/packages/ui-chats/package.json
@@ -10,6 +10,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build:types": "vue-tsc -p ./tsconfig.build.json",
+		"typecheck": "vue-tsc --noEmit -p ./tsconfig.build.json",
 		"lint:fix": "npx biome check --write ./src",
 		"biome:ci:gh": "biome ci ./src --reporter=github",
 		"test:unit": "node -e \"process.exit(0)\"",

--- a/packages/ui-chats/package.json
+++ b/packages/ui-chats/package.json
@@ -10,7 +10,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build:types": "vue-tsc -p ./tsconfig.build.json",
-		"typecheck": "vue-tsc --noEmit -p ./tsconfig.build.json",
+		"typecheck": "vue-tsc --noEmit -p ./tsconfig.typecheck.json",
 		"lint:fix": "npx biome check --write ./src",
 		"biome:ci:gh": "biome ci ./src --reporter=github",
 		"test:unit": "node -e \"process.exit(0)\"",

--- a/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-size-exceeded-error.vue
+++ b/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-size-exceeded-error.vue
@@ -24,7 +24,7 @@ interface IChatMessageSizeExceededErrorProps {
 	selfSide?: boolean;
 }
 
-const props = withDefaults(defineProps<IChatMessageSizeExceededErrorProps>(), {
+withDefaults(defineProps<IChatMessageSizeExceededErrorProps>(), {
 	selfSide: false,
 });
 </script>

--- a/packages/ui-chats/tsconfig.typecheck.json
+++ b/packages/ui-chats/tsconfig.typecheck.json
@@ -1,0 +1,13 @@
+{
+	// Separate from tsconfig.build: needs baseUrl at repo root so monorepo path
+	// aliases resolve; must not inherit emit/rootDir from build.
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"baseUrl": "../.."
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.vue",
+		"../../env.d.ts"
+	]
+}

--- a/packages/ui-chats/tsconfig.typecheck.json
+++ b/packages/ui-chats/tsconfig.typecheck.json
@@ -1,9 +1,12 @@
 {
 	// Separate from tsconfig.build: needs baseUrl at repo root so monorepo path
 	// aliases resolve; must not inherit emit/rootDir from build.
+	// Clear root `types: [vidstack/vue]` — these packages do not need it, and
+	// package-local installs do not guarantee vidstack in resolution roots.
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"baseUrl": "../.."
+		"baseUrl": "../..",
+		"types": []
 	},
 	"include": [
 		"src/**/*.ts",

--- a/packages/ui-datalist/package.json
+++ b/packages/ui-datalist/package.json
@@ -4,7 +4,7 @@
 	"description": "Toolkit for building data lists in webitel ui system",
 	"scripts": {
 		"build:types": "vue-tsc -p ./tsconfig.build.json",
-		"typecheck": "vue-tsc --noEmit -p ./tsconfig.build.json",
+		"typecheck": "vue-tsc --noEmit -p ./tsconfig.typecheck.json",
 		"lint:fix": "npx biome check --write ./src",
 		"biome:ci:gh": "biome ci ./src --reporter=github",
 		"test:unit": "node -e \"process.exit(0)\"",

--- a/packages/ui-datalist/package.json
+++ b/packages/ui-datalist/package.json
@@ -4,6 +4,7 @@
 	"description": "Toolkit for building data lists in webitel ui system",
 	"scripts": {
 		"build:types": "vue-tsc -p ./tsconfig.build.json",
+		"typecheck": "vue-tsc --noEmit -p ./tsconfig.build.json",
 		"lint:fix": "npx biome check --write ./src",
 		"biome:ci:gh": "biome ci ./src --reporter=github",
 		"test:unit": "node -e \"process.exit(0)\"",

--- a/packages/ui-datalist/tsconfig.typecheck.json
+++ b/packages/ui-datalist/tsconfig.typecheck.json
@@ -1,0 +1,13 @@
+{
+	// Separate from tsconfig.build: needs baseUrl at repo root so monorepo path
+	// aliases resolve; must not inherit emit/rootDir from build.
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"baseUrl": "../.."
+	},
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.vue",
+		"../../env.d.ts"
+	]
+}

--- a/packages/ui-datalist/tsconfig.typecheck.json
+++ b/packages/ui-datalist/tsconfig.typecheck.json
@@ -1,9 +1,12 @@
 {
 	// Separate from tsconfig.build: needs baseUrl at repo root so monorepo path
 	// aliases resolve; must not inherit emit/rootDir from build.
+	// Clear root `types: [vidstack/vue]` — these packages do not need it, and
+	// package-local installs do not guarantee vidstack in resolution roots.
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
-		"baseUrl": "../.."
+		"baseUrl": "../..",
+		"types": []
 	},
 	"include": [
 		"src/**/*.ts",

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"src/**/*.ts",
+		"env.d.ts"
+	]
+}

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,7 +1,9 @@
 {
+	// Root-only CI typecheck — excludes packages/* (each package has its own job).
 	"extends": "./tsconfig.json",
 	"include": [
 		"src/**/*.ts",
+		"docs/pages/**/*.ts",
 		"env.d.ts"
 	]
 }


### PR DESCRIPTION
## Summary
- Split typecheck CI into per-package jobs gated by `dorny/paths-filter` (same pattern as lint/test)
- Add per-package `typecheck` scripts and root `tsconfig.typecheck.json` so CI checks only the touched package(s)

## Test plan
- [ ] Open PR that only touches e.g. `packages/ui-datalist` — only `typecheck-ui-datalist` (+ `changes`) should run
- [ ] Open/trigger with shared change (`package.json` / `tsconfig*.json`) — all typecheck jobs should run
- [ ] Confirm `typecheck-root` still covers `src/**` and `docs/pages/**`

Refs: [WTEL-9942](https://webitel.atlassian.net/browse/WTEL-9942)


Made with [Cursor](https://cursor.com)

[WTEL-9942]: https://webitel.atlassian.net/browse/WTEL-9942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ