### PR TITLE
feat(ui-datalist): gate IM chat queue behind staging env [WTEL-9821]

### DIFF
--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/composables/useQueueTypeOptions.ts
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/composables/useQueueTypeOptions.ts
@@ -9,10 +9,16 @@ export function useQueueTypeOptions() {
 		t(`objects.queue.type.${value}`);
 
 	const options = computed(() =>
-		Object.entries(QueueType).map(([, value]) => ({
-			value,
-			label: mapQueueTypeToLabel(value),
-		})),
+		Object.entries(QueueType)
+			// staging only https://webitel.atlassian.net/browse/WS-2
+			.filter(
+				([, value]) =>
+					import.meta.env.VITE_STAGING_ENV || value !== QueueType.IM_CHAT_QUEUE,
+			)
+			.map(([, value]) => ({
+				value,
+				label: mapQueueTypeToLabel(value),
+			})),
 	);
 
 	return {


### PR DESCRIPTION
## Summary
- Hide `IM_CHAT_QUEUE` from `useQueueTypeOptions` unless `VITE_STAGING_ENV` is set

## Test plan
- [ ] Without `VITE_STAGING_ENV`: queue type filter omits IM chat queue
- [ ] With `VITE_STAGING_ENV=true`: IM chat queue appears in options


Made with [Cursor](https://cursor.com)