### PR TITLE
fix: add fullsreen lister for scroll observers[WTEL-9968]

### DIFF
--- a/packages/ui-chats/src/ui/messaging/composables/useChatScroll.ts
+++ b/packages/ui-chats/src/ui/messaging/composables/useChatScroll.ts
@@ -50,6 +50,8 @@ export const useChatScroll = ({
 	let lastVisibleMessageEl: HTMLElement | null = null;
 	let prevScrollHeight = 0;
 	let resizeObserver: ResizeObserver | null = null;
+	let isViewportTransition = false;
+	let viewportTransitionTimer: ReturnType<typeof setTimeout> | null = null;
 	/**
 	 * @author PolinaSukhorukova-webitel
 	 *
@@ -113,6 +115,12 @@ export const useChatScroll = ({
 
 			const newScrollHeight = el.scrollHeight;
 
+			if (isViewportTransition) {
+				prevScrollHeight = newScrollHeight;
+				updateScrollToBottomBtnVisibility(el);
+				return;
+			}
+
 			const wasNearBottom =
 				el.scrollTop + el.clientHeight >= prevScrollHeight - bottomThreshold;
 			const contentGrown = newScrollHeight > prevScrollHeight;
@@ -156,6 +164,19 @@ export const useChatScroll = ({
 		newUnseenMessagesCount.value = 0;
 		resetScrollToBottomBtn();
 	};
+
+	const onFullscreenChange = () => {
+		isViewportTransition = true;
+
+		if (viewportTransitionTimer) clearTimeout(viewportTransitionTimer);
+
+		viewportTransitionTimer = setTimeout(() => {
+			isViewportTransition = false;
+			viewportTransitionTimer = null;
+		}, 500);
+	};
+
+	document.addEventListener('fullscreenchange', onFullscreenChange);
 
 	watch(
 		() => messages.value?.length,
@@ -215,6 +236,8 @@ export const useChatScroll = ({
 
 	onUnmounted(() => {
 		stopStickToBottomObserving();
+		document.removeEventListener('fullscreenchange', onFullscreenChange);
+		if (viewportTransitionTimer) clearTimeout(viewportTransitionTimer);
 	});
 
 	return {

--- a/packages/ui-chats/src/ui/messaging/composables/useChatScroll.ts
+++ b/packages/ui-chats/src/ui/messaging/composables/useChatScroll.ts
@@ -176,6 +176,13 @@ export const useChatScroll = ({
 		}, 500);
 	};
 
+	/**
+	 * @author PolinaSukhorukova-webitel
+	 *
+	 * WTEL-9968 (https://webitel.atlassian.net/browse/WTEL-9968)
+	 * to avoid extra bottom scroll when chat is in fullscreen
+	 */
+
 	document.addEventListener('fullscreenchange', onFullscreenChange);
 
 	watch(

--- a/packages/ui-chats/src/ui/messaging/composables/useObserveHeightUntilStable.ts
+++ b/packages/ui-chats/src/ui/messaging/composables/useObserveHeightUntilStable.ts
@@ -54,6 +54,12 @@ export const useObserveHeightUntilStable = (
 		observer.observe(chatContainer.value);
 	};
 
+	/**
+	 * @author PolinaSukhorukova-webitel
+	 *
+	 * WTEL-9968 (https://webitel.atlassian.net/browse/WTEL-9968)
+	 * to avoid extra bottom scroll when chat is in fullscreen
+	 */
 	document.addEventListener('fullscreenchange', onFullscreenChange);
 
 	onUnmounted(() => {

--- a/packages/ui-chats/src/ui/messaging/composables/useObserveHeightUntilStable.ts
+++ b/packages/ui-chats/src/ui/messaging/composables/useObserveHeightUntilStable.ts
@@ -12,6 +12,19 @@ export const useObserveHeightUntilStable = (
 	callback: () => void,
 ) => {
 	let observer: ResizeObserver | null = null;
+	let isViewportTransition = false;
+	let viewportTransitionTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const onFullscreenChange = () => {
+		isViewportTransition = true;
+
+		if (viewportTransitionTimer) clearTimeout(viewportTransitionTimer);
+
+		viewportTransitionTimer = setTimeout(() => {
+			isViewportTransition = false;
+			viewportTransitionTimer = null;
+		}, 500);
+	};
 
 	const stopObserve = () => {
 		observer?.disconnect();
@@ -26,7 +39,8 @@ export const useObserveHeightUntilStable = (
 
 		observer = new ResizeObserver(() => {
 			const currentClientHeight = chatContainer.value?.clientHeight;
-			callback();
+
+			if (!isViewportTransition) callback();
 
 			if (currentClientHeight === lastClientHeight) {
 				stableCount++;
@@ -40,7 +54,13 @@ export const useObserveHeightUntilStable = (
 		observer.observe(chatContainer.value);
 	};
 
-	onUnmounted(stopObserve);
+	document.addEventListener('fullscreenchange', onFullscreenChange);
+
+	onUnmounted(() => {
+		stopObserve();
+		document.removeEventListener('fullscreenchange', onFullscreenChange);
+		if (viewportTransitionTimer) clearTimeout(viewportTransitionTimer);
+	});
 
 	return {
 		startObserve,


### PR DESCRIPTION
## Проблема:
коли відкриваємо відео на повний екран змінюються розміри як контейнеру чату так і самого контенту, того смикались мої обзервери і спрацьовува скрол

## Вирішення
Додала лістенер на подію fullscreen і виходжу з обзервера на час перемальовування лейауту після виходу з повноекранного режиму
