### PR TITLE
fix: pinia store and table header types [WTEL-9942]

### DIFF
--- a/packages/ui-datalist/src/index.ts
+++ b/packages/ui-datalist/src/index.ts
@@ -1,3 +1,5 @@
 import { createTableStore } from './modules/table/createTableStore.store';
+import type { DatalistTableHeader } from './modules/types/tableStore.types';
 
+export type { DatalistTableHeader };
 export { createTableStore };

--- a/packages/ui-datalist/src/modules/_shared/createDatalistStore.ts
+++ b/packages/ui-datalist/src/modules/_shared/createDatalistStore.ts
@@ -61,10 +61,8 @@ export const createDatalistStore = <
 	}
 
 	if (thisStoreType === DatalistStoreProvider.Pinia) {
-		// TODO(types): a Pinia StoreDefinition is a valid store factory (callable,
-		// returns a store exposing `$patch`), but its generic-extracted shape does
-		// not structurally match PatchableStoreFactory. Reconcile the two factory
-		// types instead of asserting here.
+		// Pinia StoreDefinition is a valid PatchableStoreFactory at runtime;
+		// PatchableStore includes StoreGeneric so consumers can use storeToRefs.
 		return definePiniaStore(namespace, () =>
 			storeBody({
 				...config,

--- a/packages/ui-datalist/src/modules/filter-presets/stores/createFilterPresetsStore.ts
+++ b/packages/ui-datalist/src/modules/filter-presets/stores/createFilterPresetsStore.ts
@@ -1,11 +1,25 @@
 import { ref } from 'vue';
 import type { EnginePresetQuery } from 'webitel-sdk';
 
+import { createDatalistStore } from '../../_shared/createDatalistStore';
 import { PersistedStorageType } from '../../persist/PersistedStorage.types';
 import { usePersistedStorage } from '../../persist/usePersistedStorage';
 import { tableStoreBody } from '../../table/createTableStore.store';
+import type { PatchableStoreFactory } from '../../types/createDatalistStore.types';
 import PresetQueryAPI from '../api/PresetQuery';
 import { headers } from './headers/headers';
+
+const presetsTableConfig = {
+	/* PresetQueryAPI's add/update take preset-specific params, so only the
+	   ApiModule-conforming methods the table store actually calls go in */
+	apiModule: {
+		getList: PresetQueryAPI.getList,
+		get: PresetQueryAPI.get,
+		delete: PresetQueryAPI.delete,
+	},
+	headers,
+	disablePersistence: true as const,
+};
 
 export const filterPresetsStoreBody = (namespace = 'presets') => {
 	const presetsNamespace = namespace.endsWith('presets')
@@ -40,17 +54,10 @@ export const filterPresetsStoreBody = (namespace = 'presets') => {
 		await restorePreset();
 	};
 
-	const tableStore = tableStoreBody<EnginePresetQuery>(presetsNamespace, {
-		/* PresetQueryAPI's add/update take preset-specific params, so only the
-		   ApiModule-conforming methods the table store actually calls go in */
-		apiModule: {
-			getList: PresetQueryAPI.getList,
-			get: PresetQueryAPI.get,
-			delete: PresetQueryAPI.delete,
-		},
-		headers,
-		disablePersistence: true,
-	});
+	const tableStore = tableStoreBody<EnginePresetQuery>(
+		presetsNamespace,
+		presetsTableConfig,
+	);
 
 	const resetPreset = () => {
 		presetId.value = null;
@@ -65,6 +72,23 @@ export const filterPresetsStoreBody = (namespace = 'presets') => {
 	};
 };
 
-export const createFilterPresetsStore = (namespace: string) => {
-	return () => filterPresetsStoreBody(namespace);
+export type FilterPresetsStore = ReturnType<typeof filterPresetsStoreBody>;
+
+/**
+ * Pinia store factory (via createDatalistStore), same pattern as createTableStore.
+ * Previously returned a plain object factory — that broke storeToRefs / props typed
+ * as `() => StoreGeneric` and forced app-level asPiniaStoreFactory casts.
+ */
+export const createFilterPresetsStore = (
+	namespace: string,
+): PatchableStoreFactory<FilterPresetsStore> => {
+	const presetsNamespace = namespace.endsWith('presets')
+		? namespace
+		: `${namespace}/presets`;
+
+	return createDatalistStore<FilterPresetsStore, EnginePresetQuery>({
+		namespace: presetsNamespace,
+		config: presetsTableConfig,
+		storeBody: () => filterPresetsStoreBody(namespace),
+	});
 };

--- a/packages/ui-datalist/src/modules/types/createDatalistStore.types.ts
+++ b/packages/ui-datalist/src/modules/types/createDatalistStore.types.ts
@@ -1,3 +1,4 @@
+import type { StoreGeneric } from 'pinia';
 import type { Ref } from 'vue';
 
 import type { useTableStoreConfig } from './tableStore.types';
@@ -32,10 +33,15 @@ export interface CreateDatalistStoreParams<
 }
 
 /**
- * PatchableStore is needed to indicate that the store we are using also has a storePatch method (previously $patch)
- * */
-export type PatchableStore<T extends StoreInstance> = T & {
-	$patch: (val: Patch) => void;
-};
+ * PatchableStore is needed to indicate that the store we are using also has a storePatch method (previously $patch).
+ *
+ * Intersects StoreGeneric so pinia helpers (`storeToRefs`) and props typed as
+ * `() => StoreGeneric` accept the factory result — runtime pinia stores already
+ * satisfy StoreGeneric; the previous plain-record shape forced app-level casts.
+ */
+export type PatchableStore<T extends StoreInstance> = T &
+	StoreGeneric & {
+		$patch: (val: Patch) => void;
+	};
 export type PatchableStoreFactory<T extends StoreInstance> =
 	() => PatchableStore<T>;

--- a/src/api/transformers/camelToSnake/camelToSnake.transformer.js
+++ b/src/api/transformers/camelToSnake/camelToSnake.transformer.js
@@ -1,5 +1,8 @@
 import { objCamelToSnake } from '../../../scripts/caseConverters.js';
 
+/**
+ * @param {string[]=} [skipKeys] keys to leave in camelCase
+ */
 const camelToSnakeTransformer = (skipKeys) => (obj) =>
 	objCamelToSnake(obj, skipKeys);
 export default camelToSnakeTransformer;

--- a/src/api/transformers/snakeToCamel/snakeToCamel.transformer.js
+++ b/src/api/transformers/snakeToCamel/snakeToCamel.transformer.js
@@ -1,5 +1,8 @@
 import { objSnakeToCamel } from '../../../scripts/caseConverters.js';
 
+/**
+ * @param {string[]=} [skipKeys] keys to leave in snake_case
+ */
 const snakeToCamelTransformer = (skipKeys) => (obj) =>
 	objSnakeToCamel(obj, skipKeys);
 export default snakeToCamelTransformer;

--- a/src/components/_internals/composables/useWtTable/useWtTable.ts
+++ b/src/components/_internals/composables/useWtTable/useWtTable.ts
@@ -13,12 +13,16 @@ export const useWtTable = ({ headers }) => {
 			)
 			.map((header: WtTableHeader) => {
 				if (!header.text && header.locale) {
+					const translate = t as (key: string, ...args: unknown[]) => string;
 					return {
 						...header,
 						text:
 							typeof header.locale === 'string'
-								? t(header.locale)
-								: t(...header.locale),
+								? translate(header.locale)
+								: translate(
+										String(header.locale[0]),
+										...header.locale.slice(1),
+									),
 					};
 				}
 				return header;

--- a/src/components/wt-table/types/WtTable.ts
+++ b/src/components/wt-table/types/WtTable.ts
@@ -1,12 +1,14 @@
 export type WtTableHeader = {
 	value: string;
-	locale?:
-		| string
-		| [
-				string,
-		  ];
+	/**
+	 * i18n key, or args for `t(key, ...params)` (plural count, named params, …).
+	 * Plain arrays are allowed — header defs often don't use `as const` tuples.
+	 */
+	locale?: string | (string | number | Record<string, unknown>)[];
 	text?: string;
 	width?: string;
-	sort?: boolean;
+	/** API/query field name when it differs from `value` */
+	field?: string;
+	sort?: boolean | null;
 	show?: boolean;
 };

--- a/src/modules/CSVExport/composables/useCSVExport.ts
+++ b/src/modules/CSVExport/composables/useCSVExport.ts
@@ -18,7 +18,11 @@ interface CSVExportOptions {
 
 const CSV_EXPORT_BATCH_SIZE = 5000;
 
-export function useCSVExport({ selected }: { selected: Ref<number[]> }) {
+export function useCSVExport({
+	selected,
+}: {
+	selected: Ref<Array<string | number>>;
+}) {
 	const CSVExportInstance = ref<null | InstanceType<typeof CSVExport>>(null);
 	const route = useRoute();
 


### PR DESCRIPTION
## Summary
- Make `PatchableStore` Pinia-compatible (`StoreGeneric` intersection) and route filter presets through `createDatalistStore`
- Widen `WtTableHeader` / CSV export typing and export `DatalistTableHeader` from ui-datalist
- Make `snakeToCamel` / `camelToSnake` `skipKeys` optional so callers need no dummy args

## Test plan
- [ ] `npm run typecheck` (or package type builds) passes for affected packages
- [ ] Filter presets store still creates/loads/applies as before
- [ ] Table headers with optional `field` / locale objects still render and sort

Ticket: https://webitel.atlassian.net/browse/WTEL-9942


Made with [Cursor](https://cursor.com)