### PR TITLE
fix: widen prop types for consumer typecheck [WTEL-9942]

### DIFF
--- a/src/components/wt-empty/wt-empty.vue
+++ b/src/components/wt-empty/wt-empty.vue
@@ -92,8 +92,10 @@ import { greaterOrEqual, smallerOrEqual } from '../../scripts/compareSize';
 import WtImage from '../wt-image/wt-image.vue';
 
 const props = defineProps({
+	// SVG URL string (vite) or module object — matches wt-image `src`
 	image: {
 		type: [
+			String,
 			Object,
 			null,
 		],

--- a/src/components/wt-input-number/wt-input-number.vue
+++ b/src/components/wt-input-number/wt-input-number.vue
@@ -75,7 +75,6 @@
 </template>
 
 <script setup lang="ts">
-import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import type { InputNumberProps } from 'primevue';
 import {
 	computed,
@@ -87,6 +86,7 @@ import {
 	useTemplateRef,
 } from 'vue';
 import { ComponentSize, MessageColor, MessageVariant } from '../../enums';
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import { useValidation } from '../../mixins/validationMixin/useValidation';
 import { useInputControl } from '../_internals/composables';
 

--- a/src/components/wt-input-number/wt-input-number.vue
+++ b/src/components/wt-input-number/wt-input-number.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script setup lang="ts">
-import type { RegleFieldStatus } from '@regle/core';
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import type { InputNumberProps } from 'primevue';
 import {
 	computed,
@@ -104,7 +104,7 @@ interface WtInputNumberProps extends /* @vue-ignore */ InputNumberProps {
 	maxFractionDigits?: number;
 	showButtons?: boolean;
 	v?: Record<string, unknown>;
-	regleValidation?: RegleFieldStatus<number>;
+	regleValidation?: WtRegleFieldValidation;
 	customValidators?: unknown[];
 	hideInputInfo?: boolean;
 }

--- a/src/components/wt-input-text/wt-input-text.vue
+++ b/src/components/wt-input-text/wt-input-text.vue
@@ -63,7 +63,6 @@
 </template>
 
 <script setup lang="ts">
-import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import type { InputTextProps } from 'primevue';
 import {
 	computed,
@@ -74,6 +73,7 @@ import {
 	useTemplateRef,
 } from 'vue';
 import { ComponentSize, MessageColor, MessageVariant } from '../../enums';
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import { useValidation } from '../../mixins/validationMixin/useValidation';
 import { useInputControl } from '../_internals/composables';
 

--- a/src/components/wt-input-text/wt-input-text.vue
+++ b/src/components/wt-input-text/wt-input-text.vue
@@ -63,7 +63,7 @@
 </template>
 
 <script setup lang="ts">
-import type { RegleFieldStatus } from '@regle/core';
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import type { InputTextProps } from 'primevue';
 import {
 	computed,
@@ -87,7 +87,7 @@ interface WtInputTextProps extends /* @vue-ignore */ InputTextProps {
 	required?: boolean;
 	preventTrim?: boolean;
 	v?: Record<string, unknown>;
-	regleValidation?: RegleFieldStatus<string>;
+	regleValidation?: WtRegleFieldValidation;
 	customValidators?: unknown[];
 	hideInputInfo?: boolean;
 	hideInputValue?: boolean;

--- a/src/components/wt-multi-select/wt-multi-select.vue
+++ b/src/components/wt-multi-select/wt-multi-select.vue
@@ -131,6 +131,7 @@
 </template>
 
 <script setup lang="ts">
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import type { SelectProps } from 'primevue';
 import { computed, onMounted, toRefs, useSlots, useTemplateRef } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -182,7 +183,7 @@ interface Props extends SelectProps {
 	chipsView?: boolean;
 	labelProps?: object;
 	v?: Record<string, unknown>;
-	regleValidation?: RegleFieldStatus<string>;
+	regleValidation?: WtRegleFieldValidation;
 	customValidators?: unknown[];
 }
 

--- a/src/components/wt-multi-select/wt-multi-select.vue
+++ b/src/components/wt-multi-select/wt-multi-select.vue
@@ -131,11 +131,11 @@
 </template>
 
 <script setup lang="ts">
-import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import type { SelectProps } from 'primevue';
 import { computed, onMounted, toRefs, useSlots, useTemplateRef } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { ChipColor, ComponentSize, MessageVariant } from '../../enums';
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import { useValidation } from '../../mixins/validationMixin/useValidation';
 import { useSelect } from '../_internals/composables/useSelect/useSelect';
 import { toArray } from '../_internals/composables/useSelect/useSelectUtils';

--- a/src/components/wt-password/wt-password.vue
+++ b/src/components/wt-password/wt-password.vue
@@ -50,7 +50,6 @@
 </template>
 
 <script setup lang="ts">
-import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import type { PasswordProps } from 'primevue';
 import {
 	computed,
@@ -61,6 +60,7 @@ import {
 	useTemplateRef,
 } from 'vue';
 import { ComponentSize, MessageColor, MessageVariant } from '../../enums';
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import { useValidation } from '../../mixins/validationMixin/useValidation';
 import { useInputControl } from '../_internals/composables';
 

--- a/src/components/wt-password/wt-password.vue
+++ b/src/components/wt-password/wt-password.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script setup lang="ts">
-import type { RegleFieldStatus } from '@regle/core';
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import type { PasswordProps } from 'primevue';
 import {
 	computed,
@@ -72,7 +72,7 @@ interface WtPasswordProps extends /* @vue-ignore */ PasswordProps {
 	required?: boolean;
 	toggleMask?: boolean;
 	v?: Record<string, unknown>;
-	regleValidation?: RegleFieldStatus<string>;
+	regleValidation?: WtRegleFieldValidation;
 	customValidators?: unknown[];
 }
 

--- a/src/components/wt-player/wt-player.vue
+++ b/src/components/wt-player/wt-player.vue
@@ -55,7 +55,6 @@
 	lang="ts"
 >
 import 'vidstack/bundle';
-import type { MediaSrc } from 'vidstack';
 import { ref, toRefs, watch } from 'vue';
 import { ComponentSize } from '../../enums';
 import SettingsPanel, {
@@ -63,6 +62,7 @@ import SettingsPanel, {
 } from '../_shared/settings-panel/settings-panel.vue';
 import TimeGroup from '../wt-vidstack-player/components/panels/playback-controls-panel/components/time-group.vue';
 import { useVidstackSrc } from '../wt-vidstack-player/composables/useVidstackSrc';
+import type { SrcInput } from '../wt-vidstack-player/utils/normalizeVidstackMediaSrc';
 import MuteButton from './src/components/buttons/mute-button.vue';
 import PlayButton from './src/components/buttons/play-button.vue';
 import TimeSlider from './src/components/sliders/time-slider.vue';
@@ -70,10 +70,10 @@ import VolumeSlider from './src/components/sliders/volume-slider.vue';
 
 interface Props {
 	/**
-	 * vidstack media src
-	 * @type {MediaSrc}
+	 * Media source. Accepts a URL string or `{ src, type }` with an untyped
+	 * MIME (API payloads); useVidstackSrc normalizes to a vidstack PlayerSrc.
 	 */
-	src?: MediaSrc;
+	src?: string | SrcInput;
 	/**
 	 * Media id
 	 * @type {string}

--- a/src/components/wt-single-select/wt-single-select.vue
+++ b/src/components/wt-single-select/wt-single-select.vue
@@ -107,6 +107,7 @@
 </template>
 
 <script setup lang="ts">
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import type { SelectProps } from 'primevue';
 import { computed, onMounted, toRefs, useSlots, useTemplateRef } from 'vue';
 import { ComponentSize, MessageColor, MessageVariant } from '../../enums';
@@ -152,7 +153,7 @@ interface Props extends SelectProps {
 	allowCustomValues?: boolean;
 	labelProps?: object;
 	v?: Record<string, unknown>;
-	regleValidation?: RegleFieldStatus<string>;
+	regleValidation?: WtRegleFieldValidation;
 	customValidators?: unknown[];
 }
 

--- a/src/components/wt-single-select/wt-single-select.vue
+++ b/src/components/wt-single-select/wt-single-select.vue
@@ -107,10 +107,10 @@
 </template>
 
 <script setup lang="ts">
-import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import type { SelectProps } from 'primevue';
 import { computed, onMounted, toRefs, useSlots, useTemplateRef } from 'vue';
 import { ComponentSize, MessageColor, MessageVariant } from '../../enums';
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import { useValidation } from '../../mixins/validationMixin/useValidation';
 import { useSelect } from '../_internals/composables/useSelect/useSelect';
 

--- a/src/components/wt-time-input/wt-time-input.vue
+++ b/src/components/wt-time-input/wt-time-input.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup lang="ts">
-import type { RegleFieldStatus } from '@regle/core';
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 
 interface WtTimeInputProps {
 	/**
@@ -56,7 +56,7 @@ interface WtTimeInputProps {
 	/**
 	 * Regle validation object
 	 */
-	regleValidation?: RegleFieldStatus<number>;
+	regleValidation?: WtRegleFieldValidation;
 	/**
 	 * Custom validators for vuelidate
 	 */

--- a/src/components/wt-timepicker/wt-timepicker.vue
+++ b/src/components/wt-timepicker/wt-timepicker.vue
@@ -72,11 +72,10 @@
 </template>
 
 <script setup lang="ts">
-import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import { computed, nextTick, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
-
 import { ComponentSize, MessageVariant } from '../../enums';
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import { useValidation } from '../../mixins/validationMixin/useValidation';
 
 // const SEC_IN_DAY = 60 * 60 * 24;

--- a/src/components/wt-timepicker/wt-timepicker.vue
+++ b/src/components/wt-timepicker/wt-timepicker.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script setup lang="ts">
-import type { RegleFieldStatus } from '@regle/core';
+import type { WtRegleFieldValidation } from '../../mixins/validationMixin/regle/WtRegleFieldValidation';
 import { computed, nextTick, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -123,7 +123,7 @@ interface WtTimepickerProps {
 	/**
 	 * Regle validation object
 	 */
-	regleValidation?: RegleFieldStatus<number>;
+	regleValidation?: WtRegleFieldValidation;
 	/**
 	 * Custom validators for vuelidate
 	 */

--- a/src/mixins/validationMixin/regle/WtRegleFieldValidation.ts
+++ b/src/mixins/validationMixin/regle/WtRegleFieldValidation.ts
@@ -1,0 +1,14 @@
+import type { SuperCompatibleRegleFieldStatus } from '@regle/core';
+
+/**
+ * Regle field surface consumed by UI inputs (`$error` / `$errors` only).
+ *
+ * Derived from Regle's SuperCompatibleRegleFieldStatus so both useRegle
+ * (RegleFieldStatus) and @regle/schemas (RegleSchemaFieldStatus, which omits
+ * `$pending`) are assignable. Picking keeps the prop from requiring members
+ * that vary across Regle packages/versions.
+ */
+export type WtRegleFieldValidation = Pick<
+	SuperCompatibleRegleFieldStatus,
+	'$error' | '$errors'
+>;

--- a/src/mixins/validationMixin/regle/useRegleValidation.ts
+++ b/src/mixins/validationMixin/regle/useRegleValidation.ts
@@ -1,8 +1,10 @@
-import type { RegleFieldStatus } from '@regle/core';
 import { type ComputedRef, computed, type Ref } from 'vue';
+import type { WtRegleFieldValidation } from './WtRegleFieldValidation';
+
+export type { WtRegleFieldValidation } from './WtRegleFieldValidation';
 
 export type UseFieldValidationParams = {
-	field?: Ref<RegleFieldStatus<string>>;
+	field?: Ref<WtRegleFieldValidation>;
 };
 
 export type UseFieldValidationReturn = {


### PR DESCRIPTION
## Summary
- Accept both `useRegle` and `@regle/schemas` field status on `regleValidation` via `WtRegleFieldValidation` (`Pick` from `SuperCompatibleRegleFieldStatus`)
- Allow `wt-empty` `image` as string (SVG URL) or object, matching `wt-image`
- Loosen `wt-player` `src` to `string | SrcInput` so API MIME strings typecheck; `useVidstackSrc` still normalizes

Unblocks CRM (and similar apps) `vue-tsc` for these prop mismatches.

## Test plan
- [ ] `npm run build:types` emits updated declarations
- [ ] Consumer app (e.g. CRM) linked/bumped to this build: `npm run typecheck` green for former Regle / `wt-empty` / `wt-player` errors
- [ ] Smoke: empty state still renders with table-empty SVG; player still plays recording with API `mimeType`


Made with [Cursor](https://cursor.com)