### PR TITLE
refactor(types): fix strictNullChecks violations in api-services and ui-datalist

### DIFF
--- a/packages/api-services/src/api/transformers/camelToSnake/camelToSnake.transformer.ts
+++ b/packages/api-services/src/api/transformers/camelToSnake/camelToSnake.transformer.ts
@@ -1,7 +1,7 @@
 import { objCamelToSnake } from '../../../utils/api/caseConverters';
 
 const camelToSnakeTransformer =
-	(skipKeys = []) =>
+	(skipKeys: string[] = []) =>
 	(obj) =>
 		objCamelToSnake(obj, skipKeys);
 export default camelToSnakeTransformer;

--- a/packages/api-services/src/api/transformers/notify/notify.transformer.ts
+++ b/packages/api-services/src/api/transformers/notify/notify.transformer.ts
@@ -12,7 +12,7 @@ const notifyTransformer = (notificationObject) => {
     so, create a callback which will send notification with params, passed to it
      */
 		const callback = ({ type, text }) =>
-			apiServicesConfig.eventBus.$emit('notification', {
+			apiServicesConfig.eventBus?.$emit('notification', {
 				type,
 				text,
 			});

--- a/packages/api-services/src/api/transformers/snakeToCamel/snakeToCamel.transformer.ts
+++ b/packages/api-services/src/api/transformers/snakeToCamel/snakeToCamel.transformer.ts
@@ -1,7 +1,7 @@
 import { objSnakeToCamel } from '../../../utils/api/caseConverters';
 
 const snakeToCamelTransformer =
-	(skipKeys = []) =>
+	(skipKeys: string[] = []) =>
 	(obj) =>
 		objSnakeToCamel(obj, skipKeys);
 export default snakeToCamelTransformer;

--- a/packages/api-services/src/config/config.ts
+++ b/packages/api-services/src/config/config.ts
@@ -2,10 +2,12 @@ import type { I18n } from 'vue-i18n';
 import { messages } from '../locale';
 
 export type ApiServicesConfig = {
+	/** `null` until the host app calls `setConfig`. */
 	eventBus?: {
 		$emit: (event: string, payload: unknown) => unknown;
-	};
-	i18n?: I18n;
+	} | null;
+	/** `null` until the host app calls `setConfig`. */
+	i18n?: I18n | null;
 };
 
 export const config: ApiServicesConfig = {
@@ -17,9 +19,11 @@ export const setConfig = (conf: ApiServicesConfig) => {
 	Object.assign(config, conf);
 
 	// Automatically merge api-services locale messages into the provided i18n instance
-	if (conf.i18n?.global) {
+	// (hoisted into a local so the narrowing survives into the callback below)
+	const i18n = conf.i18n;
+	if (i18n?.global) {
 		Object.entries(messages).forEach(([locale, localeMessages]) => {
-			conf.i18n.global.mergeLocaleMessage(locale, localeMessages);
+			i18n.global.mergeLocaleMessage(locale, localeMessages);
 		});
 	}
 };

--- a/packages/api-services/src/scripts/downloadFile/types/downloadFile.types.ts
+++ b/packages/api-services/src/scripts/downloadFile/types/downloadFile.types.ts
@@ -4,5 +4,6 @@ export interface DownloadFileOptions {
 	response: any;
 	fileFormat: FileFormat;
 	filename?: string;
-	mimetype?: string;
+	/** `null` is the explicit "detect from response headers" default. */
+	mimetype?: string | null;
 }

--- a/packages/api-services/src/utils/api/caseConverters.ts
+++ b/packages/api-services/src/utils/api/caseConverters.ts
@@ -62,14 +62,14 @@ const convertObject =
 		return newObj;
 	};
 
-export const objSnakeToCamel = (obj, skipKeys = []) => {
+export const objSnakeToCamel = (obj, skipKeys: string[] = []) => {
 	return convertObject({
 		self: objSnakeToCamel,
 		converter: snakeToCamel,
 	})(obj, skipKeys);
 };
 
-export const objCamelToSnake = (obj, skipKeys = []) => {
+export const objCamelToSnake = (obj, skipKeys: string[] = []) => {
 	return convertObject({
 		self: objCamelToSnake,
 		converter: camelToSnake,

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-assignee/case-assignee-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-assignee/case-assignee-filter-value-field.vue
@@ -19,7 +19,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { requiredIf } from '@vuelidate/validators';
 import { WtCheckbox, WtMultiSelect } from '@webitel/ui-sdk/components';
-import { computed, onMounted, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { CaseAssigneeFilterConfig } from './index';
@@ -29,7 +29,12 @@ type ModelValue = {
 	unassigned: boolean;
 };
 
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		list: [],
+		unassigned: false,
+	}),
+});
 
 const props = defineProps<{
 	filterConfig: CaseAssigneeFilterConfig;
@@ -42,16 +47,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			list: [],
-			unassigned: false,
-		};
-	}
-};
-onMounted(() => initModel());
 
 const v$ = useVuelidate<{
 	model: ModelValue;

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-close-reason-groups/case-close-reason-groups-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-close-reason-groups/case-close-reason-groups-filter-value-field.vue
@@ -30,7 +30,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import { WtMultiSelect, WtSingleSelect } from '@webitel/ui-sdk/components';
-import { computed, onMounted, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import {
@@ -42,7 +42,12 @@ type ModelValue = {
 	selection: string;
 	conditions: string;
 };
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		selection: '',
+		conditions: '',
+	}),
+});
 const { t } = useI18n();
 
 const updateSelected = (value) => {
@@ -56,16 +61,6 @@ const getConditionList = (params) => {
 		...params,
 	});
 };
-
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			selection: '',
-			conditions: '',
-		};
-	}
-};
-onMounted(() => initModel());
 
 const v$ = useVuelidate<{
 	model: ModelValue;

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-sla-condition/case-sla-condition-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-sla-condition/case-sla-condition-filter-value-field.vue
@@ -30,7 +30,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import { WtMultiSelect, WtSingleSelect } from '@webitel/ui-sdk/components';
-import { computed, onMounted, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { slasConditionsSearchMethod, slasSearchMethod } from './config.js';
@@ -39,7 +39,12 @@ type ModelValue = {
 	selection: string;
 	conditions: string;
 };
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		selection: '',
+		conditions: '',
+	}),
+});
 const { t } = useI18n();
 
 const updateSelected = (value) => {
@@ -54,15 +59,6 @@ const getConditionList = async (params) => {
 	});
 };
 
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			selection: '',
-			conditions: '',
-		};
-	}
-};
-onMounted(() => initModel());
 const v$ = useVuelidate<{
 	model: ModelValue;
 }>(

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-status/case-status-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-status/case-status-filter-value-field.vue
@@ -29,7 +29,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import { WtMultiSelect, WtSingleSelect } from '@webitel/ui-sdk/components';
-import { computed, onMounted, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import {
@@ -41,7 +41,12 @@ type ModelValue = {
 	selection: string;
 	conditions: string;
 };
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		selection: '',
+		conditions: '',
+	}),
+});
 const { t } = useI18n();
 
 const updateSelected = (value) => {
@@ -55,16 +60,6 @@ const getConditionList = (params) => {
 		...params,
 	});
 };
-
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			selection: '',
-			conditions: '',
-		};
-	}
-};
-onMounted(() => initModel());
 
 const v$ = useVuelidate<{
 	model: ModelValue;

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/contact-group/contact-group-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/contact-group/contact-group-filter-value-field.vue
@@ -38,7 +38,12 @@ type ModelValue = {
 	unassigned?: boolean | null;
 };
 
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		list: [],
+		unassigned: null,
+	}),
+});
 
 const emit = defineEmits<{
 	'update:invalid': [
@@ -95,19 +100,8 @@ const vUnassigned = computed(() => {
 	return modelValidation.unassigned;
 });
 
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			list: [],
-			unassigned: null,
-		};
-	}
-};
-
 onMounted(() => {
 	if (!props?.disableValidation) v$.value.$touch();
-
-	initModel();
 });
 
 watch(

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-file/has-file-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-file/has-file-filter-value-field.vue
@@ -13,7 +13,8 @@ import { useBooleanFilterValueValidation } from '../../composables/booleanFilter
 import { BooleanFilterModelValue } from '../../enums/options/BooleanFilterOptions';
 import HasOptionFilterValueField from '../_shared/has-options/has-option-filter-value-field.vue';
 
-const model = defineModel<BooleanFilterModelValue>();
+// `null` is what the shared has-option field writes when the selection is cleared.
+const model = defineModel<BooleanFilterModelValue | null>();
 
 const { v$ } = useBooleanFilterValueValidation<BooleanFilterModelValue>(model);
 

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-rating/has-rating-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-rating/has-rating-filter-value-field.vue
@@ -13,7 +13,8 @@ import { useBooleanFilterValueValidation } from '../../composables/booleanFilter
 import { BooleanFilterModelValue } from '../../enums/options/BooleanFilterOptions';
 import HasOptionFilterValueField from '../_shared/has-options/has-option-filter-value-field.vue';
 
-const model = defineModel<BooleanFilterModelValue>();
+// `null` is what the shared has-option field writes when the selection is cleared.
+const model = defineModel<BooleanFilterModelValue | null>();
 
 const { v$ } = useBooleanFilterValueValidation<BooleanFilterModelValue>(model);
 

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-transcription/has-transcription-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-transcription/has-transcription-filter-value-field.vue
@@ -13,7 +13,8 @@ import { useBooleanFilterValueValidation } from '../../composables/booleanFilter
 import { BooleanFilterModelValue } from '../../enums/options/BooleanFilterOptions';
 import HasOptionFilterValueField from '../_shared/has-options/has-option-filter-value-field.vue';
 
-const model = defineModel<BooleanFilterModelValue>();
+// `null` is what the shared has-option field writes when the selection is cleared.
+const model = defineModel<BooleanFilterModelValue | null>();
 
 const { v$ } = useBooleanFilterValueValidation<BooleanFilterModelValue>(model);
 

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-user/has-user-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-user/has-user-filter-value-field.vue
@@ -21,7 +21,8 @@ const props = defineProps<{
 	hideLabel?: boolean;
 }>();
 
-const model = defineModel<BooleanFilterModelValue>();
+// `null` is what the shared has-option field writes when the selection is cleared.
+const model = defineModel<BooleanFilterModelValue | null>();
 
 let v$: ReturnType<typeof useBooleanFilterValueValidation>['v$'] | null = null;
 if (!props.disableValidation) {

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/composables/booleanFilterToolkit.ts
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/composables/booleanFilterToolkit.ts
@@ -23,12 +23,14 @@ export const usePrettifyBooleanValuePreview = (
 export const useBooleanFilterValueValidation = <
 	T extends BooleanFilterModelValue,
 >(
-	model: ModelRef<T>,
+	// `defineModel<T>()` without a default always widens to `T | undefined`, and the
+	// shared has-option field writes `null` when the selection is cleared.
+	model: ModelRef<T | null | undefined>,
 ) => {
 	const v$ = useVuelidate(
 		computed(() => ({
 			model: {
-				required: (v: T) => !(!v && v !== false),
+				required: (v: T | null | undefined) => !(!v && v !== false),
 			},
 		})),
 		{


### PR DESCRIPTION
Groundwork for enabling `strict` in `tsconfig.base.json`. **The flag itself is not flipped in this PR** — see *Why strict isn't on yet* below.

## Why

`strict: false` is set explicitly in `tsconfig.base.json`. Turning it on surfaces ~1300 distinct errors repo-wide, ~1030 of which are the `noImplicitAny` family (untyped params in `.ts`/`.vue`, plus untyped imports of the remaining `.js` sources). Splitting the rollout: land everything in the `strict` family **except** `noImplicitAny` first — that's where the actual bug-catching value is — then lift `noImplicitAny` per package.

Under `strict` minus `noImplicitAny` the repo started at 279 errors. This PR clears 110 of them.

| package | before | after |
|---|---|---|
| `api-services` | 40 | **0** ✅ |
| `styleguide` | 0 | **0** ✅ |
| `ui-chats` | 10 | 10 |
| `ui-datalist` | 183 | **113** |
| root `src` | 46 | 46 |
| **total** | **279** | **169** |

## Why strict isn't on yet

Flipping `strict` while 169 errors remain would land a red baseline, and a permanently-red check trains everyone to ignore it. The flag goes in as the final commit of the series, once the count reaches zero. Every fix here is independently correct and verified green under the **current** config, so this PR is safe to merge on its own.

## Root causes fixed

16 files touched, 110 errors cleared — each fix is one upstream cause collapsing a cluster, not a patch at the call sites.

**`skipKeys = []` inferred as `never[]`** (35 errors)
`snakeToCamel`/`camelToSnake` transformers and `objSnakeToCamel`/`objCamelToSnake` all defaulted `skipKeys` to `[]` with no annotation. Under `strict` that's `never[]`, so every `camelToSnake(['some_key'])` call site failed. Four `string[]` annotations cleared the entire api-services cluster across `flow.ts`, `queues.ts`, `users.ts`, `contacts.ts`.

**`defineModel<T>()` without a default** (~40 errors)
Six filter-value fields declared `defineModel<ModelValue>()` — type `ModelValue | undefined` — then populated it from an `onMounted(initModel)` hook, so every `model.value.x` downstream was "possibly undefined" and `useVuelidate(..., { model })` rejected the `ModelRef<T | undefined>`.

Replaced with the `defineModel<ModelValue>({ default: ... })` form **already used by `case-service-filter-value-field.vue`** — which was the one component in that directory with zero errors. Pattern taken from the codebase, not invented. `initModel` and its `onMounted` are now dead and removed.

**`null` sentinels typed as `| undefined`**
- `ApiServicesConfig.eventBus` / `.i18n` initialise to `null` but were typed `?:` (i.e. `| undefined`) — widened to `| null`.
- `DownloadFileOptions.mimetype` defaults to `null`, was typed `string`.
- The four `has-*` boolean fields typed their model `BooleanFilterModelValue` (= `boolean`), but the shared has-option field writes `null` on clear — widened to `| null`, and `useBooleanFilterValueValidation` now accepts `ModelRef<T | null | undefined>`, which is what `defineModel<T>()` always produces.

In each case the *type* was wrong, not the value — no runtime change.

**Narrowing lost in a callback**
`setConfig` dereferenced `conf.i18n` inside a `forEach`, where the `if (conf.i18n?.global)` narrowing doesn't reach. Hoisted into a local.

## Please review these two

**1. One behaviour change.** Removing `initModel` also removes an `update:modelValue` emit that fired on mount when the parent passed no value. The value emitted was the empty/cleared shape, so no filter state is lost — but a parent relying on that mount-time emit would no longer receive it. This is inherent to typing the model correctly; the alternative was 18 non-null assertions, i.e. a suppression.

**2. A latent runtime bug the types found.** `notify.transformer.ts:15` called `apiServicesConfig.eventBus.$emit(...)` unguarded, while the identical call 30 lines below has `?.`. It would throw a TypeError for any host app that uses the notify transformer without configuring an event bus. Added `?.` to match the sibling call — flagging it because it's a logic change, not a type change.

## Not done

No `any`, no `as` casts, no `@ts-ignore`/`@ts-expect-error`, no tsconfig loosening, no `exclude` additions.

## Verification

- `npm run typecheck` — clean in root and all four packages
- `npm run test:unit` — 352 passed, 3 skipped
- biome clean (3 pre-existing `noExplicitAny` warnings in generated `src/gen/` remain, untouched)

## Remaining 169, for follow-ups

- **ui-datalist 113** — `createTableStore.store.ts` (14) and `usePersistedStorage.ts` (13) next. Same root pattern in both: `let x = null` / `ref(null)` infers as type `null` under `strictNullChecks`, so every later assignment fails.
- **root `src` 46** — spread thin, `accessStore.ts` (7) largest.
- **ui-chats 10** — smallest.