### PR TITLE
refactor(types): fix strictNullChecks violations in ui-datalist stores and persist

### DIFF
--- a/packages/ui-datalist/src/modules/_shared/createDatalistStore.ts
+++ b/packages/ui-datalist/src/modules/_shared/createDatalistStore.ts
@@ -27,7 +27,9 @@ const defaultStoreType = DatalistStoreProvider.Pinia;
  * */
 export const makeThisToRefs = <StoreBody extends object>(
 	store: StoreBody,
-	storeType: DatalistStoreProviderType,
+	// optional: falls back to `defaultStoreType` below, and every store config
+	// declares `storeType` as optional
+	storeType?: DatalistStoreProviderType,
 ): ToRefs<StoreBody> => {
 	const thisStoreType = storeType || defaultStoreType;
 

--- a/packages/ui-datalist/src/modules/permissions-page/scripts/PermissionsApiModule.ts
+++ b/packages/ui-datalist/src/modules/permissions-page/scripts/PermissionsApiModule.ts
@@ -1,5 +1,4 @@
-import type { ApiModule } from '@webitel/ui-sdk/src/api/types/ApiModule';
-
+import type { TableApiModule } from '../../types/tableStore.types';
 import type {
 	PermissionEntity,
 	RawPermissionsApiModule,
@@ -13,9 +12,9 @@ import type {
  */
 export const PermissionsApiModule = (
 	rawApiModule: RawPermissionsApiModule,
-): ApiModule<PermissionEntity> => {
+): TableApiModule<PermissionEntity> => {
 	return {
 		getList: rawApiModule.getPermissionsList,
 		patch: rawApiModule.patchPermissions,
-	} as unknown as ApiModule<PermissionEntity>;
+	} as unknown as TableApiModule<PermissionEntity>;
 };

--- a/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
+++ b/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
@@ -40,7 +40,8 @@ export interface PersistedPropertyConfig {
 		{ value, name },
 	) => Promise<void>;
 	onRestore?: (
-		restore: (name: string) => Promise<PersistableValue>,
+		// resolves `undefined` when no storage held a value for `name`
+		restore: (name: string) => Promise<PersistableValue | undefined>,
 		name: string,
 	) => Promise<void>;
 }

--- a/packages/ui-datalist/src/modules/persist/useLocalStoragePersistedStorage.ts
+++ b/packages/ui-datalist/src/modules/persist/useLocalStoragePersistedStorage.ts
@@ -7,15 +7,14 @@ const makePath = (storagePath: string, key: string) => `${storagePath}/${key}`;
 export const useLocalStoragePersistedStorage = ({
 	storagePath = '',
 }: {
-	storagePath: string;
+	// optional at the call site — defaults to '' above
+	storagePath?: string;
 }): StorageLike => {
 	const getItem = async (key: string) => {
 		const value = localStorage.getItem(makePath(storagePath, key));
-		try {
-			return value.split(separator).join();
-		} catch {
-			return value;
-		}
+		// was a try/catch relying on `.split` throwing on the null miss
+		if (value === null) return null;
+		return value.split(separator).join();
 	};
 
 	const setItem = async (key: string, inputValue: string | string[]) => {

--- a/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
+++ b/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
@@ -1,10 +1,11 @@
-import { watch } from 'vue';
+import { type WatchHandle, watch } from 'vue';
 
 import {
 	type PersistableValue,
 	type PersistedPropertyConfig,
 	type PersistedStorageController,
 	PersistedStorageType,
+	type StorageLike,
 } from './PersistedStorage.types';
 import { useLocalStoragePersistedStorage } from './useLocalStoragePersistedStorage';
 import { useRoutePersistedStorage } from './useRoutePersistedStorage';
@@ -20,25 +21,30 @@ export const usePersistedStorage = ({
 	onStore,
 	onRestore,
 }: PersistedPropertyConfig): PersistedStorageController => {
-	let unwatch = null;
+	let unwatch: WatchHandle | null = null;
 
-	const setItemFns = [];
-	const getItemFns: Array<(name: string) => Promise<PersistableValue>> = [];
-	const removeItemFns = [];
+	const setItemFns: StorageLike['setItem'][] = [];
+	const getItemFns: StorageLike['getItem'][] = [];
+	const removeItemFns: StorageLike['removeItem'][] = [];
 
+	// `null` entries are kept: callers below pick the first non-null value, so the
+	// per-storage misses have to stay in the list to preserve priority order.
 	const composedValueGetter = async (
 		name: string,
-	): Promise<PersistableValue[]> => {
+	): Promise<Array<PersistableValue | null>> => {
 		const settledResults = await Promise.allSettled(
 			getItemFns.map((getter) => getter(name)),
 		);
 
-		return settledResults.reduce((acc, result) => {
-			if (result.status === 'fulfilled') {
-				acc.push(result.value);
-			}
-			return acc;
-		}, [] as PersistableValue[]);
+		return settledResults.reduce(
+			(acc, result) => {
+				if (result.status === 'fulfilled') {
+					acc.push(result.value);
+				}
+				return acc;
+			},
+			[] as Array<PersistableValue | null>,
+		);
 	};
 
 	const storages = Array.isArray(configStorages)

--- a/packages/ui-datalist/src/modules/table/createTableStore.store.ts
+++ b/packages/ui-datalist/src/modules/table/createTableStore.store.ts
@@ -93,7 +93,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 
 	const dataList: Ref<Entity[]> = ref([]);
 	const selected: Ref<Entity[]> = ref([]);
-	const error = ref(null);
+	const error = ref<unknown>(null);
 	const isLoading = ref(false);
 
 	const updateSelected = (value: Entity[]) => {
@@ -125,7 +125,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 		try {
 			const { items, next } = await apiModule.getList(params);
 
-			dataList.value = items;
+			dataList.value = items ?? [];
 
 			/**
 			 * @author: @Oleksandr Palonnyi
@@ -134,7 +134,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 			 *
 			 * link to refactor task - https://webitel.atlassian.net/browse/WTEL-8599
 			 * */
-			updateSelected(filterSelected(items));
+			updateSelected(filterSelected(items ?? []));
 
 			$patchPaginationStore({
 				next,
@@ -169,7 +169,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 		try {
 			const { items, next } = await apiModule.getList(params);
 
-			dataList.value.push(...items);
+			dataList.value.push(...(items ?? []));
 			$patchPaginationStore({
 				next,
 			});
@@ -191,7 +191,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 		set(changes, path, value);
 
 		try {
-			await apiModule.patch({
+			await apiModule.patch?.({
 				changes,
 				parentId: parentId.value,
 				id: item.id,
@@ -211,7 +211,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 					_els,
 				];
 		const deleteEl = (el: Entity) => {
-			return apiModule.delete({
+			return apiModule.delete?.({
 				id: el.id,
 				etag: el.etag,
 				parentId: parentId.value,

--- a/packages/ui-datalist/src/modules/types/tableStore.types.ts
+++ b/packages/ui-datalist/src/modules/types/tableStore.types.ts
@@ -17,8 +17,16 @@ export type DatalistTableHeader = WtTableHeader & {
 
 export type TrackSelectedRowBy<T> = (row: T) => T;
 
+/**
+ * Every method on {@link ApiModule} is optional, but a table store cannot load
+ * anything without `getList`, so it is required here. `patch`/`delete` stay
+ * optional and are called defensively.
+ */
+export type TableApiModule<Entity> = ApiModule<Entity> &
+	Required<Pick<ApiModule<Entity>, 'getList'>>;
+
 export interface useTableStoreConfig<Entity> {
-	apiModule: ApiModule<Entity>;
+	apiModule: TableApiModule<Entity>;
 	headers: DatalistTableHeader[];
 	disablePersistence?: boolean | [];
 	storeType?: DatalistStoreProviderType;


### PR DESCRIPTION
Second increment of the staged `strict` rollout. **Stacked on #1588** — that PR is the base, so review it first (or merge it and this retargets to `main`).

`strict` is still not flipped. Progress under `strict` minus `noImplicitAny`:

| package | start of series | after #1588 | this PR |
|---|---|---|---|
| `api-services` | 40 | **0** ✅ | **0** ✅ |
| `styleguide` | 0 | **0** ✅ | **0** ✅ |
| `ui-chats` | 10 | 10 | 10 |
| `ui-datalist` | 183 | 113 | **86** |
| root `src` | 46 | 46 | **42** |
| **total** | **279** | **169** | **138** |

Root `src` drops without being touched here — it typechecks `packages/api-services/src/config/config.ts` through the workspace symlink, so the config fix from #1588 counts there too.

## `usePersistedStorage` (13 errors)

- **`setItemFns`/`removeItemFns` declared as bare `[]`** → `never[]`, so every `.push()` and every later call of an element failed. Typed all three arrays off the existing `StorageLike` interface — which also corrected `getItemFns`, whose hand-written annotation claimed `Promise<PersistableValue>` while the storages actually return `Promise<PersistableValue | null>`.
- **`let unwatch = null`** infers as type `null`, so both the `watch()` assignment and the `unwatch?.()` call failed. Now `WatchHandle | null`.
- **`composedValueGetter`** claimed `PersistableValue[]` but deliberately keeps the per-storage `null` misses — callers pick the first non-null value and storage priority order matters. Corrected the return type rather than filtering the nulls, which would have changed that ordering.
- **`PersistedPropertyConfig.onRestore`** typed its `restore` callback as resolving `PersistableValue`, but the implementation returns `.find()`'s result, i.e. `| undefined`.
- **`useLocalStoragePersistedStorage`** declared `storagePath` required while defaulting it to `''`.
- **`getItem` used a `try/catch` around `.split()` to handle the localStorage miss**, returning `value` (i.e. `null`) from the catch. Replaced with an explicit `if (value === null) return null`. Same result, no longer depends on a TypeError for control flow.

## `createTableStore` (14 errors)

- **`makeThisToRefs` declared `storeType` required** while its body does `storeType || defaultStoreType`, and every store config declares the field optional. Making the parameter optional also cleared the same error in the card and permissions stores.
- **`ref(null)` for `error`** infers type `null` → both `error.value = err` assignments failed. Now `ref<unknown>(null)`.
- **`ApiModule` has every method optional**, but a table store cannot function without `getList`. Added a named `TableApiModule<Entity>` requiring it, used by `useTableStoreConfig`. `patch`/`delete` are genuinely optional and are now called with `?.` — an api module lacking them would previously have thrown a TypeError at the call site, so this is not a regression.
- **`getList` returns `items?: Entity[]`**, so the three uses of `items` needed `?? []`. The api layer always merges `getDefaultGetListResponse()` (`{items: [], next: false}`) into the response, so this matches existing runtime behaviour.

## The tightening immediately caught a real bug

Requiring `getList` made the typechecker reject `createPermissionsStore.ts:150`. `PermissionsApiModule` returns `{getList, patch}` but declared its return type as the fully-optional `ApiModule<PermissionEntity>` through an `as unknown as` cast — so passing it into a table store config was unsound, and the cast was hiding it. Its return type now says `TableApiModule<PermissionEntity>`, which is what it actually returns.

This is the kind of thing the whole exercise is for, and it argues for keeping the requirement rather than loosening it back.

## Note for the eventual release

`useTableStoreConfig.apiModule` is now stricter, so a consumer repo passing an api module without `getList` will fail typecheck after the next `ui-datalist` release. Nothing in this workspace does — consumers pass whole api-services client modules — but it is a public type tightening worth a line in the release notes.

## Not done

No `any`, no new `as` casts, no `@ts-ignore`/`@ts-expect-error`, no tsconfig loosening.

## Verification

- `npm run typecheck` — clean in root and all four packages
- `npm run test:unit` — 352 passed, 3 skipped
- biome clean

## Remaining 138

- **ui-datalist 86** — `FiltersManager.ts` (9), `dynamic-filter-search.vue` (7), `dynamic-filter-config-form.vue` (7), the `from-to` filter fields (12 across score/rating/duration/date-time).
- **root `src` 42** — `accessStore.ts` (7), `useTableColumnDrag.ts` (5), rest spread thin.
- **ui-chats 10**.