### PR TITLE
refactor(types): take ui-chats to zero strictNullChecks errors

### DIFF
--- a/packages/ui-chats/src/ui/messaging/composables/useObserveHeightUntilStable.ts
+++ b/packages/ui-chats/src/ui/messaging/composables/useObserveHeightUntilStable.ts
@@ -34,7 +34,8 @@ export const useObserveHeightUntilStable = (
 	const startObserve = () => {
 		if (!chatContainer.value) return;
 
-		let lastClientHeight = chatContainer.value.clientHeight;
+		// undefined once the container unmounts mid-observation
+		let lastClientHeight: number | undefined = chatContainer.value.clientHeight;
 		let stableCount = 0;
 
 		observer = new ResizeObserver(() => {

--- a/packages/ui-chats/src/ui/messaging/modules/message/components/chat-message.vue
+++ b/packages/ui-chats/src/ui/messaging/modules/message/components/chat-message.vue
@@ -136,7 +136,7 @@ const isTransferAgent = computed(
 
 const isBot = computed<boolean>(() => props.message.member?.type === 'bot');
 
-const getClientUsername = computed<string>(() => {
+const getClientUsername = computed<string | undefined>(() => {
 	if (isTransferAgent.value) return props.message.member?.name;
 	if (isSelfSide.value) return props?.agentName;
 

--- a/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-document.vue
+++ b/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-document.vue
@@ -38,11 +38,14 @@ const documentSize = computed(() => {
 });
 
 function downloadDocument() {
-	if (!props.file) return;
+	// `url` is optional on ChatMessageFile; without it `a.href` used to be set to
+	// the string "undefined" and the click navigated to a bogus relative URL
+	if (!props.file?.url) return;
 	const a = document.createElement('a');
 	a.href = props.file.url;
 	a.target = '_blank';
-	a.download = props.file.name;
+	// empty `download` lets the browser derive the filename from the URL
+	a.download = props.file.name ?? '';
 	a.click();
 }
 </script>

--- a/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-player.vue
+++ b/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-player.vue
@@ -35,7 +35,8 @@ import type { ChatMessageFile } from '../../../../types/ChatMessage.types';
 
 const props = defineProps<{
 	file: ChatMessageFile;
-	type: string;
+	// mirrors ChatMessageFile.mime, which is optional; already optional-chained below
+	type?: string;
 }>();
 
 const emit = defineEmits<{

--- a/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessage.ts
+++ b/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessage.ts
@@ -15,8 +15,10 @@ export const useChatMessages = (
 ) => {
 	function showChatDate(index: number): boolean {
 		const { prevMessage, message } = getMessage(index);
-		const prevDate = +prevMessage?.createdAt || 0;
-		const currentDate = +message?.createdAt || 0;
+		// `Number(undefined)` is NaN, so the `|| 0` fallback already covered the
+		// missing-createdAt case — this just states it in a way the checker accepts
+		const prevDate = Number(prevMessage?.createdAt) || 0;
+		const currentDate = Number(message?.createdAt) || 0;
 		return (
 			!!prevMessage &&
 			formatDate(prevDate, FormatDateMode.DATE) !==

--- a/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessageFile.ts
+++ b/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessageFile.ts
@@ -3,7 +3,8 @@ import { computed, type Ref, toRef } from 'vue';
 import type { ChatMessageFile } from '../../../types/ChatMessage.types';
 
 export function useChatMessageFile(
-	file: ChatMessageFile | Ref<ChatMessageFile>,
+	// `ChatMessageType.file` is optional, and every read below is optional-chained
+	file: ChatMessageFile | Ref<ChatMessageFile | undefined> | undefined,
 ) {
 	const fileRef = toRef(file);
 
@@ -30,7 +31,8 @@ export function useChatMessageFile(
 		);
 	});
 
-	const isMediaType = (value: string) => {
+	// callers pass `fileType`/`fileSrc`, both of which are optional on the file
+	const isMediaType = (value: string | undefined) => {
 		return !!(value?.includes('audio') || value?.includes('video'));
 	};
 


### PR DESCRIPTION
Third increment of the staged `strict` rollout. **Stacked on #1589**, which is stacked on #1588 — review/merge in that order.

`strict` is still not flipped. Progress under `strict` minus `noImplicitAny`:

| package | series start | #1588 | #1589 | this PR |
|---|---|---|---|---|
| `api-services` | 40 | **0** ✅ | **0** ✅ | **0** ✅ |
| `styleguide` | 0 | **0** ✅ | **0** ✅ | **0** ✅ |
| `ui-chats` | 10 | 10 | 10 | **0** ✅ |
| `ui-datalist` | 183 | 113 | 86 | 86 |
| root `src` | 46 | 46 | 42 | 42 |
| **total** | **279** | 169 | 138 | **128** |

Three of the five units are now clean.

## The pattern here: signatures narrower than the data

Every field on `ChatMessageFile` is optional (`id?`, `name?`, `size?`, `mime?`, `url?`, `streamUrl?`), `ChatMessageType.file` is optional, and the `prev/next` message lookups return optionals. The call sites were already written defensively — optional chaining, `|| 0` fallbacks — but the signatures claimed non-optional. So these are corrections to the declarations, not new runtime guards:

- **`useChatMessageFile`** declared `file: ChatMessageFile | Ref<ChatMessageFile>` but is called with `props.message.file`. Every read inside is already `fileRef.value?.…`, so the parameter now admits `undefined`.
- **`isMediaType(value: string)`** is called with `fileType`/`fileSrc`, both optional, and its body is already `value?.includes(...)`.
- **`chat-message-player.vue`** required `type: string` while the caller passes `media.mime`. The component does `mediaSrc.value?.type?.includes('video')`, so the prop is now optional.
- **`getClientUsername`** was annotated `computed<string>`, but all three branches can produce `undefined`.
- **`useObserveHeightUntilStable`** compares against `chatContainer.value?.clientHeight`, undefined once the container unmounts mid-observation, so `lastClientHeight` cannot be typed `number`.
- **`showChatDate`** used `+prevMessage?.createdAt || 0` → `Number(...) || 0`. Identical NaN-to-0 behaviour, just expressible under strict.

## One behaviour change — please confirm

`chat-message-document.vue`'s `downloadDocument` assigned the optional `file.url` directly to `a.href`:

```ts
a.href = props.file.url;      // undefined -> attribute becomes the string "undefined"
a.download = props.file.name; // same
```

With no `url` that produced `href="undefined"`, and the synthetic click navigated to a bogus relative URL. It now returns early instead. `a.download` falls back to `''` rather than `"undefined"`, which lets the browser derive the filename from the URL.

Strictly an improvement over navigating to a broken path, but it is a logic change rather than a type change, so flagging it.

## Not done

No `any`, no new `as` casts, no `@ts-ignore`/`@ts-expect-error`, no tsconfig loosening.

## Verification

- `npm run typecheck` — clean in root and all four packages
- `npm run test:unit` — 352 passed, 3 skipped
- biome clean

## Remaining 128

- **ui-datalist 86** — `FiltersManager.ts` (9), `dynamic-filter-search.vue` (7), `dynamic-filter-config-form.vue` (7), `from-to` filter fields (~12 across score/rating/duration/date-time), `createCardStore.ts` (6).
- **root `src` 42** — `accessStore.ts` (7), `useTableColumnDrag.ts` (5), remainder spread thin.