### PR TITLE
refactor(types): fix strictNullChecks violations in filters and from-to fields

### DIFF
--- a/packages/ui-datalist/src/modules/filters/classes/Filter.ts
+++ b/packages/ui-datalist/src/modules/filters/classes/Filter.ts
@@ -53,7 +53,8 @@ export class Filter implements IFilter {
 	constructor(
 		{ name, value, label }: FilterInitParams,
 		public payload: object | undefined,
-		public config: FilterInstanceConfig,
+		// FiltersManager passes its own optional config through as the fallback
+		public config: FilterInstanceConfig | undefined,
 	) {
 		this.name = name;
 		this.value = value;

--- a/packages/ui-datalist/src/modules/filters/classes/FiltersManager.ts
+++ b/packages/ui-datalist/src/modules/filters/classes/FiltersManager.ts
@@ -21,7 +21,8 @@ export interface IFiltersManager {
 	filters: Map<FilterName, IFilter>;
 
 	hasFilter: (name: FilterName) => boolean;
-	getFilter: (name: FilterName) => IFilter;
+	/** `undefined` when no filter is registered under `name` */
+	getFilter: (name: FilterName) => IFilter | undefined;
 	addFilter: (
 		params: FilterInitParams,
 		payload?: object,
@@ -34,7 +35,7 @@ export interface IFiltersManager {
 		value?: FilterValue;
 		label?: FilterLabel;
 	}) => IFilter;
-	deleteFilter: ({ name }: { name: FilterName }) => IFilter;
+	deleteFilter: ({ name }: { name: FilterName }) => IFilter | undefined;
 
 	/**
 	 * Converts filters data to String, that can be stored
@@ -105,7 +106,7 @@ class FiltersManager implements IFiltersManager {
 		return this.filters.has(name);
 	}
 
-	getFilter(name: FilterName): IFilter {
+	getFilter(name: FilterName): IFilter | undefined {
 		return this.filters.get(name);
 	}
 
@@ -129,6 +130,10 @@ class FiltersManager implements IFiltersManager {
 		label?: FilterLabel;
 	}): IFilter {
 		const filter = this.filters.get(name);
+		if (!filter) {
+			// previously a TypeError on `filter.set` a line later
+			throw new Error(`FiltersManager: cannot update unknown filter "${name}"`);
+		}
 		filter.set({
 			value,
 			label,
@@ -136,7 +141,7 @@ class FiltersManager implements IFiltersManager {
 		return filter;
 	}
 
-	deleteFilter({ name }: { name: FilterName }): IFilter {
+	deleteFilter({ name }: { name: FilterName }): IFilter | undefined {
 		const filter = this.filters.get(name);
 		this.filters.delete(name);
 		return filter;
@@ -249,10 +254,11 @@ class FiltersManager implements IFiltersManager {
 		include?: FilterName[];
 		exclude?: FilterName[];
 	} = {}): IFilter[] {
-		const useInclude = !isEmpty(include);
-		const useExclude = !isEmpty(exclude) && !useInclude;
+		// bound to consts so the narrowing survives into the filter callback
+		const includeList = isEmpty(include) ? undefined : include;
+		const excludeList = isEmpty(exclude) ? undefined : exclude;
 
-		if (!useInclude && !useExclude) {
+		if (!includeList && !excludeList) {
 			return [
 				...this.filters.values(),
 			];
@@ -261,10 +267,10 @@ class FiltersManager implements IFiltersManager {
 		return [
 			...this.filters.values(),
 		].filter(({ name }) => {
-			if (useInclude) {
-				return include.includes(name);
-			} else if (useExclude) {
-				return !exclude.includes(name);
+			if (includeList) {
+				return includeList.includes(name);
+			} else if (excludeList) {
+				return !excludeList.includes(name);
 			}
 
 			return true;
@@ -278,24 +284,25 @@ class FiltersManager implements IFiltersManager {
 		include?: FilterName[];
 		exclude?: FilterName[];
 	} = {}): void {
-		const useInclude = !isEmpty(include);
-		const useExclude = !isEmpty(exclude) && !useInclude;
+		// bound to consts so the narrowing survives into the forEach callbacks
+		const includeList = isEmpty(include) ? undefined : include;
+		const excludeList = isEmpty(exclude) ? undefined : exclude;
 
-		if (!useInclude && !useExclude) {
+		if (!includeList && !excludeList) {
 			this.filters.clear();
 			return;
 		}
 
-		if (useInclude) {
-			include.forEach((name) => {
+		if (includeList) {
+			includeList.forEach((name) => {
 				this.filters.delete(name);
 			});
 			return;
 		}
 
-		if (useExclude) {
+		if (excludeList) {
 			this.filters.forEach((_, filterName) => {
-				if (!exclude.includes(filterName)) {
+				if (!excludeList.includes(filterName)) {
 					this.filters.delete(filterName);
 				}
 			});

--- a/packages/ui-datalist/src/modules/filters/classes/__tests__/FiltersManager.spec.ts
+++ b/packages/ui-datalist/src/modules/filters/classes/__tests__/FiltersManager.spec.ts
@@ -29,7 +29,7 @@ describe('FiltersManager', () => {
 			name: 'test',
 			value: 'test2',
 		});
-		expect(filtersManager.getFilter('test').value).toBe('test2');
+		expect(filtersManager.getFilter('test')?.value).toBe('test2');
 	});
 
 	it('should be able to getAllValues', () => {

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_shared/date-time-filter/date-time-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_shared/date-time-filter/date-time-filter-value-field.vue
@@ -26,7 +26,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import { endOfToday, startOfToday } from 'date-fns';
-import { computed, onMounted, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 type ModelValue = {
@@ -40,7 +40,12 @@ const emit = defineEmits<{
 	];
 }>();
 
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		from: startOfToday().getTime(),
+		to: endOfToday().getTime(),
+	}),
+});
 const { t } = useI18n();
 
 const from = computed(() => model.value?.from);
@@ -82,17 +87,6 @@ const handleInput = (key: keyof ModelValue, value: number) => {
 		[key]: value,
 	};
 };
-
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			from: startOfToday().getTime(),
-			to: endOfToday().getTime(),
-		};
-	}
-};
-
-onMounted(() => initModel());
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_shared/durations/duration-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_shared/durations/duration-filter-value-field.vue
@@ -31,20 +31,18 @@ type ModelValue = {
 	to: number;
 };
 
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		from: 0,
+		to: 0,
+	}),
+});
 
 const emit = defineEmits<{
 	'update:invalid': [
 		boolean,
 	];
 }>();
-
-if (!model.value) {
-	model.value = {
-		from: 0,
-		to: 0,
-	};
-}
 
 const isValueEmpty = () => {
 	return !!model?.value?.to || !!model?.value?.from;

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/rating/rating-from-to-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/rating/rating-from-to-filter-value-field.vue
@@ -28,17 +28,17 @@ import { maxValue, requiredIf } from '@vuelidate/validators';
 import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+// both bounds start out unset
 type ModelValue = {
-	from: number;
-	to: number;
+	from: number | null;
+	to: number | null;
 };
-const model = defineModel<ModelValue>();
-if (!model.value) {
-	model.value = {
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
 		from: null,
 		to: null,
-	};
-}
+	}),
+});
 
 const emit = defineEmits<{
 	'update:invalid': [
@@ -56,7 +56,10 @@ const v$ = useVuelidate<{
 			from: {
 				required: requiredIf(() => !model.value.to),
 				maxValue: maxValue(
-					model?.value?.to && model.value.from > model.value.to
+					// `from` unset used to compare as `null > to`, i.e. false -> Infinity
+					model.value.to &&
+						model.value.from !== null &&
+						model.value.from > model.value.to
 						? model.value.to
 						: Infinity,
 				),

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/score/score-from-to-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/score/score-from-to-filter-value-field.vue
@@ -34,17 +34,17 @@ import { requiredIf } from '@vuelidate/validators';
 import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+// both bounds start out unset
 type ModelValue = {
-	from: number;
-	to: number;
+	from: number | null;
+	to: number | null;
 };
-const model = defineModel<ModelValue>();
-if (!model.value) {
-	model.value = {
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
 		from: null,
 		to: null,
-	};
-}
+	}),
+});
 
 const props = withDefaults(
 	defineProps<{


### PR DESCRIPTION
Fourth increment of the staged `strict` rollout. **Stacked on #1590 → #1589 → #1588** — merge bottom-up.

`strict` still not flipped. Progress under `strict` minus `noImplicitAny`:

| unit | series start | #1588 | #1589 | #1590 | this PR |
|---|---|---|---|---|---|
| `api-services` | 40 | **0** ✅ | **0** ✅ | **0** ✅ | **0** ✅ |
| `styleguide` | 0 | **0** ✅ | **0** ✅ | **0** ✅ | **0** ✅ |
| `ui-chats` | 10 | 10 | 10 | **0** ✅ | **0** ✅ |
| `ui-datalist` | 183 | 113 | 86 | 86 | **63** |
| root `src` | 46 | 46 | 42 | 42 | 42 |
| **total** | **279** | 169 | 138 | 128 | **105** |

## from/to filter value fields — score, rating, duration, date-time

- **score and rating declared `ModelValue = {from: number; to: number}` and then initialised both bounds to `null`** on the very next line. The declared type was never true; widened to `number | null`.
- All four used `defineModel<ModelValue>()` plus an inline `if (!model.value)` or `onMounted(initModel)` to populate it — same pattern as #1588, leaving the type `| undefined` and breaking the `{...model.value}` spread in `handleInput`. Switched to the `defineModel({default})` form already established in this directory.
- **rating's `maxValue` validator** compared `model.value.from > model.value.to` with `from` possibly unset. `null > n` evaluates false, so the existing `? : Infinity` fallback already handled it — the check is now explicit rather than relying on coercion.

## FiltersManager

- **`getFilter` and `deleteFilter` are backed by `Map.get`/`Map.delete`** and can return nothing, but both declared `IFilter`. Corrected to `IFilter | undefined` on the class and the exported `IFiltersManager` interface. Only two non-test call sites exist in the repo, and one already wrote `getFilter('search')?.value` — the optionality was understood, just not typed.
- **`updateFilter` dereferenced the same lookup unchecked.** It now throws an explicit error naming the missing filter, instead of `Cannot read properties of undefined (reading 'set')` a line later. Same control flow, better message.
- **`getFiltersList` and `reset` gated on `!isEmpty(include)`**, which is not a type guard, so the params stayed optional inside the branches. Rebound to `const`s — narrowing on a const survives into the `filter`/`forEach` callbacks, which it would *not* for a parameter.
- **`Filter.config` was typed `FilterInstanceConfig`** although `FiltersManager` passes its own optional config through as the fallback. The field is only ever stored, never read inside the class.

## Worth knowing: ui-datalist has no executing tests

I updated `FiltersManager.spec.ts` for the `getFilter` signature change, then found the spec never runs:

- it imports `tests/config/config.js`, which does not exist → the suite fails to load
- the package's `test:unit` is stubbed to `node -e "process.exit(0)"`, so vitest is never invoked in CI
- `tsconfig.base.json` excludes `**/*.spec.ts`, so it is not typechecked either

So this package's only spec is both unrun and unchecked. I left the harness alone — repairing it is its own change — but flagging it since it means these store/class refactors are landing without test coverage in `ui-datalist`. The root package's 352 tests do pass.

## Not done

No `any`, no new `as` casts, no `@ts-ignore`/`@ts-expect-error`, no tsconfig loosening. One generated `auto-imports.d.ts` appeared when I ran vitest manually; deleted rather than committed.

## Verification

- `npm run typecheck` — clean in root and all four packages
- root `npm run test:unit` — 352 passed, 3 skipped
- biome clean

## Remaining 105

- **ui-datalist 63** — `dynamic-filter-search.vue` (7), `dynamic-filter-config-form.vue` (7), `createCardStore.ts` (6), `FilterConfig.ts` (4), `createFilterPresetsStore.ts` (4), rest thin.
- **root `src` 42** — `accessStore.ts` (7), `useTableColumnDrag.ts` (5), rest spread thin.