### PR TITLE
refactor(types): fix strictNullChecks violations in card and permissions stores

### DIFF
--- a/packages/ui-datalist/src/modules/card/stores/createCardStore.ts
+++ b/packages/ui-datalist/src/modules/card/stores/createCardStore.ts
@@ -33,7 +33,12 @@ export const createCardStore = <
 }: {
 	namespace: string;
 	standardValidationSchema: z.ZodType;
-	apiModule: ApiModule<Entity>;
+	/**
+	 * Every method on {@link ApiModule} is optional, but a card store reads and
+	 * writes one item, so these three are required here.
+	 */
+	apiModule: ApiModule<Entity> &
+		Required<Pick<ApiModule<Entity>, 'get' | 'add' | 'update'>>;
 	validationSchemaOptions?: RegleSchemaBehaviourOptions;
 }) => {
 	return defineStore(namespace, () => {
@@ -61,7 +66,7 @@ export const createCardStore = <
 		// processing progress vars
 		const isLoading = ref(false);
 		const isSaving = ref(false);
-		const error = ref(null); // if needed
+		const error = ref<unknown>(null); // if needed
 
 		validationSchema.value = useRegleSchema(
 			draftItemInstance,

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/classes/FilterConfig.ts
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/classes/FilterConfig.ts
@@ -74,9 +74,15 @@ export type FilterConfigSearchFilterContext = {
 };
 
 export class FilterConfig implements BaseFilterConfig {
-	name: FilterName;
-	valueInputComponent: Component;
-	valuePreviewComponent: Component;
+	/*
+	 * Definite assignment: concrete configs assign these as field initializers
+	 * (e.g. `readonly name = FilterOption.Skill`), and the constructor below only
+	 * fills them in when the params carry them. `BaseFilterConfig` requires all
+	 * three, so they cannot be declared optional here.
+	 */
+	name!: FilterName;
+	valueInputComponent!: Component;
+	valuePreviewComponent!: Component;
 	label?: ReturnType<MessageResolver> | string;
 	staticView?: boolean;
 	notDeletable: boolean;
@@ -96,7 +102,8 @@ export class FilterConfig implements BaseFilterConfig {
 			this.valuePreviewComponent = valuePreviewComponent;
 		this.notDeletable = !!notDeletable;
 		if (staticView) this.staticView = staticView;
-		if (showFilterName) this.showFilterName = showFilterName;
+		// same shape as notDeletable above; previously left undefined when falsy
+		this.showFilterName = !!showFilterName;
 	}
 }
 

--- a/packages/ui-datalist/src/modules/permissions-page/stores/createPermissionsStore.ts
+++ b/packages/ui-datalist/src/modules/permissions-page/stores/createPermissionsStore.ts
@@ -73,7 +73,7 @@ export const permissionsStoreBody = (
 	const parentId = ref<Id>();
 
 	const initialize: typeof tableStoreInitialize = (options) => {
-		parentId.value = options.parentId;
+		parentId.value = options?.parentId;
 		return tableStoreInitialize(options);
 	};
 
@@ -81,7 +81,8 @@ export const permissionsStoreBody = (
 		try {
 			await (
 				config.apiModule.patch as unknown as (payload: {
-					id: Id;
+					// undefined until `initialize` has run
+					id: Id | undefined;
 					changes: PermissionsChange[];
 				}) => Promise<unknown>
 			)({
@@ -119,7 +120,8 @@ export const permissionsStoreBody = (
 		error.value = null;
 		isLoading.value = false;
 		resetInfiniteScrollTableParamsToDefaults();
-		parentId.value = null;
+		// undefined, matching the ref type and what `initialize` assigns
+		parentId.value = undefined;
 	};
 
 	return {

--- a/src/api/types/ApiModule.ts
+++ b/src/api/types/ApiModule.ts
@@ -11,9 +11,11 @@ export interface ApiModule<Entity> {
 		next?: boolean;
 	}>;
 	get?: (params: {
-		itemId?: Id;
+		// `null` for consistency with update/patch below, and because card stores
+		// hold their id as `string | number | null`
+		itemId?: Id | null;
 		/** preferred over itemId */
-		id?: Id;
+		id?: Id | null;
 		parentId?: Id | null;
 	}) => Promise<Entity>;
 	add?: (params: {


### PR DESCRIPTION
Fifth increment of the staged `strict` rollout. **Stacked on #1591 → #1590 → #1589 → #1588** — merge bottom-up.

`strict` still not flipped. Progress under `strict` minus `noImplicitAny`:

| unit | start | #1588 | #1589 | #1590 | #1591 | this PR |
|---|---|---|---|---|---|---|
| `api-services` | 40 | **0** ✅ | **0** ✅ | **0** ✅ | **0** ✅ | **0** ✅ |
| `styleguide` | 0 | **0** ✅ | **0** ✅ | **0** ✅ | **0** ✅ | **0** ✅ |
| `ui-chats` | 10 | 10 | 10 | **0** ✅ | **0** ✅ | **0** ✅ |
| `ui-datalist` | 183 | 113 | 86 | 86 | 63 | **50** |
| root `src` | 46 | 46 | 42 | 42 | 42 | 42 |
| **total** | **279** | 169 | 138 | 128 | 105 | **92** |

## FilterConfig — the one place I used an assertion

`name`, `valueInputComponent` and `valuePreviewComponent` are required by `BaseFilterConfig`, but `FilterConfig`'s constructor only assigns them when the params carry them:

```ts
if (name) this.name = name;
```

They aren't missing — concrete configs supply them as **field initializers** instead:

```ts
class SkillFilterConfig extends WtSysTypeFilterConfig {
  readonly name = FilterOption.Skill;
  valueInputComponent = SkillFilterValueField;
  ...
}
```

So I used definite assignment assertions (`name!: FilterName`). Flagging it explicitly since I've avoided assertions everywhere else in this series: declaring the fields optional would break the `implements BaseFilterConfig` contract *and* every consumer reading `.name`, and this is the language's designated mechanism for "assigned by a subclass rather than the constructor". If you'd rather see a different shape here — an abstract base, or required constructor params — say so and I'll rework it.

Separately, `showFilterName` was assigned only when truthy, so it sat `undefined` while typed `boolean`. Now `!!showFilterName`, matching `notDeletable` one line above. Both values are falsy, so nothing downstream changes.

## createCardStore

- Same `ApiModule` situation as the table store in #1589 — every method optional, but a card store reads and writes a single item, so `get`/`add`/`update` are now required in its config type.
- `ref(null)` for `error` infers type `null`, so `error.value = err` failed.

## createPermissionsStore

- `initialize` is typed from the table store's own initialize, whose options argument is optional — `options.parentId` needed `?.`.
- The ad-hoc cast around `apiModule.patch` declared `id: Id`, but `parentId` is only populated once `initialize` has run. The declared payload now says `Id | undefined`, which is what is actually passed. The surrounding `as unknown as` cast is pre-existing; I left it alone rather than widening the change.
- `$reset` assigned `null` to a `ref<Id>()`. Now `undefined`, matching both the ref type and what `initialize` assigns.

## One change outside ui-datalist

`ApiModule.get` accepted `id?: Id` / `itemId?: Id`, while `update` and `patch` already accepted `Id | null`. Card stores hold their id as `string | number | null`, so `get` now allows null too. This makes the four methods consistent rather than `get` alone disallowing it — worth a look since `ApiModule` is public.

## Verification

- `npm run typecheck` — clean in root and all four packages
- root `npm run test:unit` — 352 passed, 3 skipped
- biome clean

No `any`, no new `as` casts, no `@ts-ignore`/`@ts-expect-error`, no tsconfig loosening. The `!` assertions in FilterConfig are the only assertions in the series so far.

## Remaining 92

- **ui-datalist 50** — `dynamic-filter-search.vue` (7), `dynamic-filter-config-form.vue` (7), `createFilterPresetsStore.ts` (4), `filterConfig/components/index.ts` (3), `table-filters-panel.vue` (3), rest thin.
- **root `src` 42** — `accessStore.ts` (7), `useTableColumnDrag.ts` (5), rest spread thin.