### PR TITLE
refactor(types): fix strictNullChecks violations across api-services, ui-chats and ui-datalist

### DIFF
--- a/packages/api-services/src/api/transformers/camelToSnake/camelToSnake.transformer.ts
+++ b/packages/api-services/src/api/transformers/camelToSnake/camelToSnake.transformer.ts
@@ -1,7 +1,7 @@
 import { objCamelToSnake } from '../../../utils/api/caseConverters';
 
 const camelToSnakeTransformer =
-	(skipKeys = []) =>
+	(skipKeys: string[] = []) =>
 	(obj) =>
 		objCamelToSnake(obj, skipKeys);
 export default camelToSnakeTransformer;

--- a/packages/api-services/src/api/transformers/notify/notify.transformer.ts
+++ b/packages/api-services/src/api/transformers/notify/notify.transformer.ts
@@ -12,7 +12,7 @@ const notifyTransformer = (notificationObject) => {
     so, create a callback which will send notification with params, passed to it
      */
 		const callback = ({ type, text }) =>
-			apiServicesConfig.eventBus.$emit('notification', {
+			apiServicesConfig.eventBus?.$emit('notification', {
 				type,
 				text,
 			});

--- a/packages/api-services/src/api/transformers/snakeToCamel/snakeToCamel.transformer.ts
+++ b/packages/api-services/src/api/transformers/snakeToCamel/snakeToCamel.transformer.ts
@@ -1,7 +1,7 @@
 import { objSnakeToCamel } from '../../../utils/api/caseConverters';
 
 const snakeToCamelTransformer =
-	(skipKeys = []) =>
+	(skipKeys: string[] = []) =>
 	(obj) =>
 		objSnakeToCamel(obj, skipKeys);
 export default snakeToCamelTransformer;

--- a/packages/api-services/src/config/config.ts
+++ b/packages/api-services/src/config/config.ts
@@ -2,10 +2,12 @@ import type { I18n } from 'vue-i18n';
 import { messages } from '../locale';
 
 export type ApiServicesConfig = {
+	/** `null` until the host app calls `setConfig`. */
 	eventBus?: {
 		$emit: (event: string, payload: unknown) => unknown;
-	};
-	i18n?: I18n;
+	} | null;
+	/** `null` until the host app calls `setConfig`. */
+	i18n?: I18n | null;
 };
 
 export const config: ApiServicesConfig = {
@@ -17,9 +19,11 @@ export const setConfig = (conf: ApiServicesConfig) => {
 	Object.assign(config, conf);
 
 	// Automatically merge api-services locale messages into the provided i18n instance
-	if (conf.i18n?.global) {
+	// (hoisted into a local so the narrowing survives into the callback below)
+	const i18n = conf.i18n;
+	if (i18n?.global) {
 		Object.entries(messages).forEach(([locale, localeMessages]) => {
-			conf.i18n.global.mergeLocaleMessage(locale, localeMessages);
+			i18n.global.mergeLocaleMessage(locale, localeMessages);
 		});
 	}
 };

--- a/packages/api-services/src/config/config.ts
+++ b/packages/api-services/src/config/config.ts
@@ -2,11 +2,9 @@ import type { I18n } from 'vue-i18n';
 import { messages } from '../locale';
 
 export type ApiServicesConfig = {
-	/** `null` until the host app calls `setConfig`. */
 	eventBus?: {
 		$emit: (event: string, payload: unknown) => unknown;
 	} | null;
-	/** `null` until the host app calls `setConfig`. */
 	i18n?: I18n | null;
 };
 
@@ -19,7 +17,6 @@ export const setConfig = (conf: ApiServicesConfig) => {
 	Object.assign(config, conf);
 
 	// Automatically merge api-services locale messages into the provided i18n instance
-	// (hoisted into a local so the narrowing survives into the callback below)
 	const i18n = conf.i18n;
 	if (i18n?.global) {
 		Object.entries(messages).forEach(([locale, localeMessages]) => {

--- a/packages/api-services/src/scripts/downloadFile/types/downloadFile.types.ts
+++ b/packages/api-services/src/scripts/downloadFile/types/downloadFile.types.ts
@@ -4,5 +4,6 @@ export interface DownloadFileOptions {
 	response: any;
 	fileFormat: FileFormat;
 	filename?: string;
-	mimetype?: string;
+	/** `null` is the explicit "detect from response headers" default. */
+	mimetype?: string | null;
 }

--- a/packages/api-services/src/scripts/downloadFile/types/downloadFile.types.ts
+++ b/packages/api-services/src/scripts/downloadFile/types/downloadFile.types.ts
@@ -4,6 +4,5 @@ export interface DownloadFileOptions {
 	response: any;
 	fileFormat: FileFormat;
 	filename?: string;
-	/** `null` is the explicit "detect from response headers" default. */
 	mimetype?: string | null;
 }

--- a/packages/api-services/src/utils/api/caseConverters.ts
+++ b/packages/api-services/src/utils/api/caseConverters.ts
@@ -62,14 +62,14 @@ const convertObject =
 		return newObj;
 	};
 
-export const objSnakeToCamel = (obj, skipKeys = []) => {
+export const objSnakeToCamel = (obj, skipKeys: string[] = []) => {
 	return convertObject({
 		self: objSnakeToCamel,
 		converter: snakeToCamel,
 	})(obj, skipKeys);
 };
 
-export const objCamelToSnake = (obj, skipKeys = []) => {
+export const objCamelToSnake = (obj, skipKeys: string[] = []) => {
 	return convertObject({
 		self: objCamelToSnake,
 		converter: camelToSnake,

--- a/packages/ui-chats/src/ui/messaging/composables/useObserveHeightUntilStable.ts
+++ b/packages/ui-chats/src/ui/messaging/composables/useObserveHeightUntilStable.ts
@@ -34,7 +34,8 @@ export const useObserveHeightUntilStable = (
 	const startObserve = () => {
 		if (!chatContainer.value) return;
 
-		let lastClientHeight = chatContainer.value.clientHeight;
+		// undefined once the container unmounts mid-observation
+		let lastClientHeight: number | undefined = chatContainer.value.clientHeight;
 		let stableCount = 0;
 
 		observer = new ResizeObserver(() => {

--- a/packages/ui-chats/src/ui/messaging/composables/useObserveHeightUntilStable.ts
+++ b/packages/ui-chats/src/ui/messaging/composables/useObserveHeightUntilStable.ts
@@ -34,7 +34,6 @@ export const useObserveHeightUntilStable = (
 	const startObserve = () => {
 		if (!chatContainer.value) return;
 
-		// undefined once the container unmounts mid-observation
 		let lastClientHeight: number | undefined = chatContainer.value.clientHeight;
 		let stableCount = 0;
 

--- a/packages/ui-chats/src/ui/messaging/modules/message/components/chat-message.vue
+++ b/packages/ui-chats/src/ui/messaging/modules/message/components/chat-message.vue
@@ -136,7 +136,7 @@ const isTransferAgent = computed(
 
 const isBot = computed<boolean>(() => props.message.member?.type === 'bot');
 
-const getClientUsername = computed<string>(() => {
+const getClientUsername = computed<string | undefined>(() => {
 	if (isTransferAgent.value) return props.message.member?.name;
 	if (isSelfSide.value) return props?.agentName;
 

--- a/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-document.vue
+++ b/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-document.vue
@@ -38,11 +38,14 @@ const documentSize = computed(() => {
 });
 
 function downloadDocument() {
-	if (!props.file) return;
+	// `url` is optional on ChatMessageFile; without it `a.href` used to be set to
+	// the string "undefined" and the click navigated to a bogus relative URL
+	if (!props.file?.url) return;
 	const a = document.createElement('a');
 	a.href = props.file.url;
 	a.target = '_blank';
-	a.download = props.file.name;
+	// empty `download` lets the browser derive the filename from the URL
+	a.download = props.file.name ?? '';
 	a.click();
 }
 </script>

--- a/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-document.vue
+++ b/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-document.vue
@@ -38,8 +38,6 @@ const documentSize = computed(() => {
 });
 
 function downloadDocument() {
-	// `url` is optional on ChatMessageFile; without it `a.href` used to be set to
-	// the string "undefined" and the click navigated to a bogus relative URL
 	if (!props.file?.url) return;
 	const a = document.createElement('a');
 	a.href = props.file.url;

--- a/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-player.vue
+++ b/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-player.vue
@@ -35,7 +35,8 @@ import type { ChatMessageFile } from '../../../../types/ChatMessage.types';
 
 const props = defineProps<{
 	file: ChatMessageFile;
-	type: string;
+	// mirrors ChatMessageFile.mime, which is optional; already optional-chained below
+	type?: string;
 }>();
 
 const emit = defineEmits<{

--- a/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-player.vue
+++ b/packages/ui-chats/src/ui/messaging/modules/message/components/details/chat-message-player.vue
@@ -35,7 +35,6 @@ import type { ChatMessageFile } from '../../../../types/ChatMessage.types';
 
 const props = defineProps<{
 	file: ChatMessageFile;
-	// mirrors ChatMessageFile.mime, which is optional; already optional-chained below
 	type?: string;
 }>();
 

--- a/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessage.ts
+++ b/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessage.ts
@@ -15,8 +15,10 @@ export const useChatMessages = (
 ) => {
 	function showChatDate(index: number): boolean {
 		const { prevMessage, message } = getMessage(index);
-		const prevDate = +prevMessage?.createdAt || 0;
-		const currentDate = +message?.createdAt || 0;
+		// `Number(undefined)` is NaN, so the `|| 0` fallback already covered the
+		// missing-createdAt case — this just states it in a way the checker accepts
+		const prevDate = Number(prevMessage?.createdAt) || 0;
+		const currentDate = Number(message?.createdAt) || 0;
 		return (
 			!!prevMessage &&
 			formatDate(prevDate, FormatDateMode.DATE) !==

--- a/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessage.ts
+++ b/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessage.ts
@@ -15,8 +15,6 @@ export const useChatMessages = (
 ) => {
 	function showChatDate(index: number): boolean {
 		const { prevMessage, message } = getMessage(index);
-		// `Number(undefined)` is NaN, so the `|| 0` fallback already covered the
-		// missing-createdAt case — this just states it in a way the checker accepts
 		const prevDate = Number(prevMessage?.createdAt) || 0;
 		const currentDate = Number(message?.createdAt) || 0;
 		return (

--- a/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessageFile.ts
+++ b/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessageFile.ts
@@ -3,7 +3,8 @@ import { computed, type Ref, toRef } from 'vue';
 import type { ChatMessageFile } from '../../../types/ChatMessage.types';
 
 export function useChatMessageFile(
-	file: ChatMessageFile | Ref<ChatMessageFile>,
+	// `ChatMessageType.file` is optional, and every read below is optional-chained
+	file: ChatMessageFile | Ref<ChatMessageFile | undefined> | undefined,
 ) {
 	const fileRef = toRef(file);
 
@@ -30,7 +31,8 @@ export function useChatMessageFile(
 		);
 	});
 
-	const isMediaType = (value: string) => {
+	// callers pass `fileType`/`fileSrc`, both of which are optional on the file
+	const isMediaType = (value: string | undefined) => {
 		return !!(value?.includes('audio') || value?.includes('video'));
 	};
 

--- a/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessageFile.ts
+++ b/packages/ui-chats/src/ui/messaging/modules/message/composables/useChatMessageFile.ts
@@ -3,7 +3,6 @@ import { computed, type Ref, toRef } from 'vue';
 import type { ChatMessageFile } from '../../../types/ChatMessage.types';
 
 export function useChatMessageFile(
-	// `ChatMessageType.file` is optional, and every read below is optional-chained
 	file: ChatMessageFile | Ref<ChatMessageFile | undefined> | undefined,
 ) {
 	const fileRef = toRef(file);
@@ -31,7 +30,6 @@ export function useChatMessageFile(
 		);
 	});
 
-	// callers pass `fileType`/`fileSrc`, both of which are optional on the file
 	const isMediaType = (value: string | undefined) => {
 		return !!(value?.includes('audio') || value?.includes('video'));
 	};

--- a/packages/ui-datalist/src/modules/_shared/createDatalistStore.ts
+++ b/packages/ui-datalist/src/modules/_shared/createDatalistStore.ts
@@ -27,8 +27,6 @@ const defaultStoreType = DatalistStoreProvider.Pinia;
  * */
 export const makeThisToRefs = <StoreBody extends object>(
 	store: StoreBody,
-	// optional: falls back to `defaultStoreType` below, and every store config
-	// declares `storeType` as optional
 	storeType?: DatalistStoreProviderType,
 ): ToRefs<StoreBody> => {
 	const thisStoreType = storeType || defaultStoreType;

--- a/packages/ui-datalist/src/modules/_shared/createDatalistStore.ts
+++ b/packages/ui-datalist/src/modules/_shared/createDatalistStore.ts
@@ -27,7 +27,9 @@ const defaultStoreType = DatalistStoreProvider.Pinia;
  * */
 export const makeThisToRefs = <StoreBody extends object>(
 	store: StoreBody,
-	storeType: DatalistStoreProviderType,
+	// optional: falls back to `defaultStoreType` below, and every store config
+	// declares `storeType` as optional
+	storeType?: DatalistStoreProviderType,
 ): ToRefs<StoreBody> => {
 	const thisStoreType = storeType || defaultStoreType;
 

--- a/packages/ui-datalist/src/modules/card/stores/createCardStore.ts
+++ b/packages/ui-datalist/src/modules/card/stores/createCardStore.ts
@@ -33,7 +33,12 @@ export const createCardStore = <
 }: {
 	namespace: string;
 	standardValidationSchema: z.ZodType;
-	apiModule: ApiModule<Entity>;
+	/**
+	 * Every method on {@link ApiModule} is optional, but a card store reads and
+	 * writes one item, so these three are required here.
+	 */
+	apiModule: ApiModule<Entity> &
+		Required<Pick<ApiModule<Entity>, 'get' | 'add' | 'update'>>;
 	validationSchemaOptions?: RegleSchemaBehaviourOptions;
 }) => {
 	return defineStore(namespace, () => {
@@ -61,7 +66,7 @@ export const createCardStore = <
 		// processing progress vars
 		const isLoading = ref(false);
 		const isSaving = ref(false);
-		const error = ref(null); // if needed
+		const error = ref<unknown>(null); // if needed
 
 		validationSchema.value = useRegleSchema(
 			draftItemInstance,

--- a/packages/ui-datalist/src/modules/filter-presets/stores/createFilterPresetsStore.ts
+++ b/packages/ui-datalist/src/modules/filter-presets/stores/createFilterPresetsStore.ts
@@ -26,7 +26,7 @@ export const filterPresetsStoreBody = (namespace = 'presets') => {
 		? namespace
 		: `${namespace}/presets`;
 
-	const presetId = ref(null);
+	const presetId = ref<number | null>(null);
 
 	const setupPresetPersistence = async () => {
 		const { restore: restorePreset, reset } = usePersistedStorage({

--- a/packages/ui-datalist/src/modules/filters/classes/Filter.ts
+++ b/packages/ui-datalist/src/modules/filters/classes/Filter.ts
@@ -53,7 +53,8 @@ export class Filter implements IFilter {
 	constructor(
 		{ name, value, label }: FilterInitParams,
 		public payload: object | undefined,
-		public config: FilterInstanceConfig,
+		// FiltersManager passes its own optional config through as the fallback
+		public config: FilterInstanceConfig | undefined,
 	) {
 		this.name = name;
 		this.value = value;

--- a/packages/ui-datalist/src/modules/filters/classes/Filter.ts
+++ b/packages/ui-datalist/src/modules/filters/classes/Filter.ts
@@ -53,7 +53,6 @@ export class Filter implements IFilter {
 	constructor(
 		{ name, value, label }: FilterInitParams,
 		public payload: object | undefined,
-		// FiltersManager passes its own optional config through as the fallback
 		public config: FilterInstanceConfig | undefined,
 	) {
 		this.name = name;

--- a/packages/ui-datalist/src/modules/filters/classes/FiltersManager.ts
+++ b/packages/ui-datalist/src/modules/filters/classes/FiltersManager.ts
@@ -131,7 +131,6 @@ class FiltersManager implements IFiltersManager {
 	}): IFilter {
 		const filter = this.filters.get(name);
 		if (!filter) {
-			// previously a TypeError on `filter.set` a line later
 			throw new Error(`FiltersManager: cannot update unknown filter "${name}"`);
 		}
 		filter.set({
@@ -211,8 +210,7 @@ class FiltersManager implements IFiltersManager {
 				const name = filterNameFromSnapshotKey(snapshotKey);
 				const valueProp = filterValuePropFromSnapshotKey(snapshotKey);
 
-				// both are undefined for keys that are neither `_lbl` nor `_val`;
-				// previously those produced an "undefined" key in the accumulator
+				// keys that are neither `_lbl` nor `_val`
 				if (name === undefined || valueProp === undefined) {
 					return filtersAcc;
 				}

--- a/packages/ui-datalist/src/modules/filters/classes/FiltersManager.ts
+++ b/packages/ui-datalist/src/modules/filters/classes/FiltersManager.ts
@@ -21,7 +21,8 @@ export interface IFiltersManager {
 	filters: Map<FilterName, IFilter>;
 
 	hasFilter: (name: FilterName) => boolean;
-	getFilter: (name: FilterName) => IFilter;
+	/** `undefined` when no filter is registered under `name` */
+	getFilter: (name: FilterName) => IFilter | undefined;
 	addFilter: (
 		params: FilterInitParams,
 		payload?: object,
@@ -34,7 +35,7 @@ export interface IFiltersManager {
 		value?: FilterValue;
 		label?: FilterLabel;
 	}) => IFilter;
-	deleteFilter: ({ name }: { name: FilterName }) => IFilter;
+	deleteFilter: ({ name }: { name: FilterName }) => IFilter | undefined;
 
 	/**
 	 * Converts filters data to String, that can be stored
@@ -105,7 +106,7 @@ class FiltersManager implements IFiltersManager {
 		return this.filters.has(name);
 	}
 
-	getFilter(name: FilterName): IFilter {
+	getFilter(name: FilterName): IFilter | undefined {
 		return this.filters.get(name);
 	}
 
@@ -129,6 +130,10 @@ class FiltersManager implements IFiltersManager {
 		label?: FilterLabel;
 	}): IFilter {
 		const filter = this.filters.get(name);
+		if (!filter) {
+			// previously a TypeError on `filter.set` a line later
+			throw new Error(`FiltersManager: cannot update unknown filter "${name}"`);
+		}
 		filter.set({
 			value,
 			label,
@@ -136,7 +141,7 @@ class FiltersManager implements IFiltersManager {
 		return filter;
 	}
 
-	deleteFilter({ name }: { name: FilterName }): IFilter {
+	deleteFilter({ name }: { name: FilterName }): IFilter | undefined {
 		const filter = this.filters.get(name);
 		this.filters.delete(name);
 		return filter;
@@ -249,10 +254,11 @@ class FiltersManager implements IFiltersManager {
 		include?: FilterName[];
 		exclude?: FilterName[];
 	} = {}): IFilter[] {
-		const useInclude = !isEmpty(include);
-		const useExclude = !isEmpty(exclude) && !useInclude;
+		// bound to consts so the narrowing survives into the filter callback
+		const includeList = isEmpty(include) ? undefined : include;
+		const excludeList = isEmpty(exclude) ? undefined : exclude;
 
-		if (!useInclude && !useExclude) {
+		if (!includeList && !excludeList) {
 			return [
 				...this.filters.values(),
 			];
@@ -261,10 +267,10 @@ class FiltersManager implements IFiltersManager {
 		return [
 			...this.filters.values(),
 		].filter(({ name }) => {
-			if (useInclude) {
-				return include.includes(name);
-			} else if (useExclude) {
-				return !exclude.includes(name);
+			if (includeList) {
+				return includeList.includes(name);
+			} else if (excludeList) {
+				return !excludeList.includes(name);
 			}
 
 			return true;
@@ -278,24 +284,25 @@ class FiltersManager implements IFiltersManager {
 		include?: FilterName[];
 		exclude?: FilterName[];
 	} = {}): void {
-		const useInclude = !isEmpty(include);
-		const useExclude = !isEmpty(exclude) && !useInclude;
+		// bound to consts so the narrowing survives into the forEach callbacks
+		const includeList = isEmpty(include) ? undefined : include;
+		const excludeList = isEmpty(exclude) ? undefined : exclude;
 
-		if (!useInclude && !useExclude) {
+		if (!includeList && !excludeList) {
 			this.filters.clear();
 			return;
 		}
 
-		if (useInclude) {
-			include.forEach((name) => {
+		if (includeList) {
+			includeList.forEach((name) => {
 				this.filters.delete(name);
 			});
 			return;
 		}
 
-		if (useExclude) {
+		if (excludeList) {
 			this.filters.forEach((_, filterName) => {
-				if (!exclude.includes(filterName)) {
+				if (!excludeList.includes(filterName)) {
 					this.filters.delete(filterName);
 				}
 			});

--- a/packages/ui-datalist/src/modules/filters/classes/FiltersManager.ts
+++ b/packages/ui-datalist/src/modules/filters/classes/FiltersManager.ts
@@ -211,6 +211,12 @@ class FiltersManager implements IFiltersManager {
 				const name = filterNameFromSnapshotKey(snapshotKey);
 				const valueProp = filterValuePropFromSnapshotKey(snapshotKey);
 
+				// both are undefined for keys that are neither `_lbl` nor `_val`;
+				// previously those produced an "undefined" key in the accumulator
+				if (name === undefined || valueProp === undefined) {
+					return filtersAcc;
+				}
+
 				if (filtersAcc[name]) {
 					filtersAcc[name][valueProp] = snapshotValue;
 				} else {

--- a/packages/ui-datalist/src/modules/filters/classes/__tests__/FiltersManager.spec.ts
+++ b/packages/ui-datalist/src/modules/filters/classes/__tests__/FiltersManager.spec.ts
@@ -29,7 +29,7 @@ describe('FiltersManager', () => {
 			name: 'test',
 			value: 'test2',
 		});
-		expect(filtersManager.getFilter('test').value).toBe('test2');
+		expect(filtersManager.getFilter('test')?.value).toBe('test2');
 	});
 
 	it('should be able to getAllValues', () => {

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/classes/FilterConfig.ts
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/classes/FilterConfig.ts
@@ -74,9 +74,15 @@ export type FilterConfigSearchFilterContext = {
 };
 
 export class FilterConfig implements BaseFilterConfig {
-	name: FilterName;
-	valueInputComponent: Component;
-	valuePreviewComponent: Component;
+	/*
+	 * Definite assignment: concrete configs assign these as field initializers
+	 * (e.g. `readonly name = FilterOption.Skill`), and the constructor below only
+	 * fills them in when the params carry them. `BaseFilterConfig` requires all
+	 * three, so they cannot be declared optional here.
+	 */
+	name!: FilterName;
+	valueInputComponent!: Component;
+	valuePreviewComponent!: Component;
 	label?: ReturnType<MessageResolver> | string;
 	staticView?: boolean;
 	notDeletable: boolean;
@@ -96,7 +102,8 @@ export class FilterConfig implements BaseFilterConfig {
 			this.valuePreviewComponent = valuePreviewComponent;
 		this.notDeletable = !!notDeletable;
 		if (staticView) this.staticView = staticView;
-		if (showFilterName) this.showFilterName = showFilterName;
+		// same shape as notDeletable above; previously left undefined when falsy
+		this.showFilterName = !!showFilterName;
 	}
 }
 

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/classes/FilterConfig.ts
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/classes/FilterConfig.ts
@@ -74,12 +74,8 @@ export type FilterConfigSearchFilterContext = {
 };
 
 export class FilterConfig implements BaseFilterConfig {
-	/*
-	 * Definite assignment: concrete configs assign these as field initializers
-	 * (e.g. `readonly name = FilterOption.Skill`), and the constructor below only
-	 * fills them in when the params carry them. `BaseFilterConfig` requires all
-	 * three, so they cannot be declared optional here.
-	 */
+	// assigned by concrete configs as field initializers, e.g.
+	// `readonly name = FilterOption.Skill`, not necessarily by this constructor
 	name!: FilterName;
 	valueInputComponent!: Component;
 	valuePreviewComponent!: Component;
@@ -102,7 +98,6 @@ export class FilterConfig implements BaseFilterConfig {
 			this.valuePreviewComponent = valuePreviewComponent;
 		this.notDeletable = !!notDeletable;
 		if (staticView) this.staticView = staticView;
-		// same shape as notDeletable above; previously left undefined when falsy
 		this.showFilterName = !!showFilterName;
 	}
 }

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_shared/date-time-filter/date-time-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_shared/date-time-filter/date-time-filter-value-field.vue
@@ -26,7 +26,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import { endOfToday, startOfToday } from 'date-fns';
-import { computed, onMounted, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 type ModelValue = {
@@ -40,7 +40,12 @@ const emit = defineEmits<{
 	];
 }>();
 
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		from: startOfToday().getTime(),
+		to: endOfToday().getTime(),
+	}),
+});
 const { t } = useI18n();
 
 const from = computed(() => model.value?.from);
@@ -82,17 +87,6 @@ const handleInput = (key: keyof ModelValue, value: number) => {
 		[key]: value,
 	};
 };
-
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			from: startOfToday().getTime(),
-			to: endOfToday().getTime(),
-		};
-	}
-};
-
-onMounted(() => initModel());
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_shared/durations/duration-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/_shared/durations/duration-filter-value-field.vue
@@ -31,20 +31,18 @@ type ModelValue = {
 	to: number;
 };
 
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		from: 0,
+		to: 0,
+	}),
+});
 
 const emit = defineEmits<{
 	'update:invalid': [
 		boolean,
 	];
 }>();
-
-if (!model.value) {
-	model.value = {
-		from: 0,
-		to: 0,
-	};
-}
 
 const isValueEmpty = () => {
 	return !!model?.value?.to || !!model?.value?.from;

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-assignee/case-assignee-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-assignee/case-assignee-filter-value-field.vue
@@ -19,7 +19,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { requiredIf } from '@vuelidate/validators';
 import { WtCheckbox, WtMultiSelect } from '@webitel/ui-sdk/components';
-import { computed, onMounted, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { CaseAssigneeFilterConfig } from './index';
@@ -29,7 +29,12 @@ type ModelValue = {
 	unassigned: boolean;
 };
 
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		list: [],
+		unassigned: false,
+	}),
+});
 
 const props = defineProps<{
 	filterConfig: CaseAssigneeFilterConfig;
@@ -42,16 +47,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			list: [],
-			unassigned: false,
-		};
-	}
-};
-onMounted(() => initModel());
 
 const v$ = useVuelidate<{
 	model: ModelValue;

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-close-reason-groups/case-close-reason-groups-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-close-reason-groups/case-close-reason-groups-filter-value-field.vue
@@ -30,7 +30,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import { WtMultiSelect, WtSingleSelect } from '@webitel/ui-sdk/components';
-import { computed, onMounted, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import {
@@ -42,7 +42,12 @@ type ModelValue = {
 	selection: string;
 	conditions: string;
 };
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		selection: '',
+		conditions: '',
+	}),
+});
 const { t } = useI18n();
 
 const updateSelected = (value) => {
@@ -56,16 +61,6 @@ const getConditionList = (params) => {
 		...params,
 	});
 };
-
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			selection: '',
-			conditions: '',
-		};
-	}
-};
-onMounted(() => initModel());
 
 const v$ = useVuelidate<{
 	model: ModelValue;

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-sla-condition/case-sla-condition-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-sla-condition/case-sla-condition-filter-value-field.vue
@@ -30,7 +30,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import { WtMultiSelect, WtSingleSelect } from '@webitel/ui-sdk/components';
-import { computed, onMounted, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import { slasConditionsSearchMethod, slasSearchMethod } from './config.js';
@@ -39,7 +39,12 @@ type ModelValue = {
 	selection: string;
 	conditions: string;
 };
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		selection: '',
+		conditions: '',
+	}),
+});
 const { t } = useI18n();
 
 const updateSelected = (value) => {
@@ -54,15 +59,6 @@ const getConditionList = async (params) => {
 	});
 };
 
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			selection: '',
-			conditions: '',
-		};
-	}
-};
-onMounted(() => initModel());
 const v$ = useVuelidate<{
 	model: ModelValue;
 }>(

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-status/case-status-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/case-status/case-status-filter-value-field.vue
@@ -29,7 +29,7 @@
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import { WtMultiSelect, WtSingleSelect } from '@webitel/ui-sdk/components';
-import { computed, onMounted, watch } from 'vue';
+import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import {
@@ -41,7 +41,12 @@ type ModelValue = {
 	selection: string;
 	conditions: string;
 };
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		selection: '',
+		conditions: '',
+	}),
+});
 const { t } = useI18n();
 
 const updateSelected = (value) => {
@@ -55,16 +60,6 @@ const getConditionList = (params) => {
 		...params,
 	});
 };
-
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			selection: '',
-			conditions: '',
-		};
-	}
-};
-onMounted(() => initModel());
 
 const v$ = useVuelidate<{
 	model: ModelValue;

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/contact-group/contact-group-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/contact-group/contact-group-filter-value-field.vue
@@ -38,7 +38,12 @@ type ModelValue = {
 	unassigned?: boolean | null;
 };
 
-const model = defineModel<ModelValue>();
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
+		list: [],
+		unassigned: null,
+	}),
+});
 
 const emit = defineEmits<{
 	'update:invalid': [
@@ -95,19 +100,8 @@ const vUnassigned = computed(() => {
 	return modelValidation.unassigned;
 });
 
-const initModel = () => {
-	if (!model.value) {
-		model.value = {
-			list: [],
-			unassigned: null,
-		};
-	}
-};
-
 onMounted(() => {
 	if (!props?.disableValidation) v$.value.$touch();
-
-	initModel();
 });
 
 watch(

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-file/has-file-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-file/has-file-filter-value-field.vue
@@ -13,7 +13,8 @@ import { useBooleanFilterValueValidation } from '../../composables/booleanFilter
 import { BooleanFilterModelValue } from '../../enums/options/BooleanFilterOptions';
 import HasOptionFilterValueField from '../_shared/has-options/has-option-filter-value-field.vue';
 
-const model = defineModel<BooleanFilterModelValue>();
+// `null` is what the shared has-option field writes when the selection is cleared.
+const model = defineModel<BooleanFilterModelValue | null>();
 
 const { v$ } = useBooleanFilterValueValidation<BooleanFilterModelValue>(model);
 

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-file/has-file-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-file/has-file-filter-value-field.vue
@@ -13,7 +13,6 @@ import { useBooleanFilterValueValidation } from '../../composables/booleanFilter
 import { BooleanFilterModelValue } from '../../enums/options/BooleanFilterOptions';
 import HasOptionFilterValueField from '../_shared/has-options/has-option-filter-value-field.vue';
 
-// `null` is what the shared has-option field writes when the selection is cleared.
 const model = defineModel<BooleanFilterModelValue | null>();
 
 const { v$ } = useBooleanFilterValueValidation<BooleanFilterModelValue>(model);

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-rating/has-rating-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-rating/has-rating-filter-value-field.vue
@@ -13,7 +13,8 @@ import { useBooleanFilterValueValidation } from '../../composables/booleanFilter
 import { BooleanFilterModelValue } from '../../enums/options/BooleanFilterOptions';
 import HasOptionFilterValueField from '../_shared/has-options/has-option-filter-value-field.vue';
 
-const model = defineModel<BooleanFilterModelValue>();
+// `null` is what the shared has-option field writes when the selection is cleared.
+const model = defineModel<BooleanFilterModelValue | null>();
 
 const { v$ } = useBooleanFilterValueValidation<BooleanFilterModelValue>(model);
 

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-rating/has-rating-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-rating/has-rating-filter-value-field.vue
@@ -13,7 +13,6 @@ import { useBooleanFilterValueValidation } from '../../composables/booleanFilter
 import { BooleanFilterModelValue } from '../../enums/options/BooleanFilterOptions';
 import HasOptionFilterValueField from '../_shared/has-options/has-option-filter-value-field.vue';
 
-// `null` is what the shared has-option field writes when the selection is cleared.
 const model = defineModel<BooleanFilterModelValue | null>();
 
 const { v$ } = useBooleanFilterValueValidation<BooleanFilterModelValue>(model);

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-transcription/has-transcription-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-transcription/has-transcription-filter-value-field.vue
@@ -13,7 +13,8 @@ import { useBooleanFilterValueValidation } from '../../composables/booleanFilter
 import { BooleanFilterModelValue } from '../../enums/options/BooleanFilterOptions';
 import HasOptionFilterValueField from '../_shared/has-options/has-option-filter-value-field.vue';
 
-const model = defineModel<BooleanFilterModelValue>();
+// `null` is what the shared has-option field writes when the selection is cleared.
+const model = defineModel<BooleanFilterModelValue | null>();
 
 const { v$ } = useBooleanFilterValueValidation<BooleanFilterModelValue>(model);
 

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-transcription/has-transcription-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-transcription/has-transcription-filter-value-field.vue
@@ -13,7 +13,6 @@ import { useBooleanFilterValueValidation } from '../../composables/booleanFilter
 import { BooleanFilterModelValue } from '../../enums/options/BooleanFilterOptions';
 import HasOptionFilterValueField from '../_shared/has-options/has-option-filter-value-field.vue';
 
-// `null` is what the shared has-option field writes when the selection is cleared.
 const model = defineModel<BooleanFilterModelValue | null>();
 
 const { v$ } = useBooleanFilterValueValidation<BooleanFilterModelValue>(model);

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-user/has-user-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-user/has-user-filter-value-field.vue
@@ -21,7 +21,6 @@ const props = defineProps<{
 	hideLabel?: boolean;
 }>();
 
-// `null` is what the shared has-option field writes when the selection is cleared.
 const model = defineModel<BooleanFilterModelValue | null>();
 
 let v$: ReturnType<typeof useBooleanFilterValueValidation>['v$'] | null = null;

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-user/has-user-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/has-user/has-user-filter-value-field.vue
@@ -21,7 +21,8 @@ const props = defineProps<{
 	hideLabel?: boolean;
 }>();
 
-const model = defineModel<BooleanFilterModelValue>();
+// `null` is what the shared has-option field writes when the selection is cleared.
+const model = defineModel<BooleanFilterModelValue | null>();
 
 let v$: ReturnType<typeof useBooleanFilterValueValidation>['v$'] | null = null;
 if (!props.disableValidation) {

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/rating/rating-from-to-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/rating/rating-from-to-filter-value-field.vue
@@ -28,7 +28,6 @@ import { maxValue, requiredIf } from '@vuelidate/validators';
 import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-// both bounds start out unset
 type ModelValue = {
 	from: number | null;
 	to: number | null;
@@ -56,7 +55,6 @@ const v$ = useVuelidate<{
 			from: {
 				required: requiredIf(() => !model.value.to),
 				maxValue: maxValue(
-					// `from` unset used to compare as `null > to`, i.e. false -> Infinity
 					model.value.to &&
 						model.value.from !== null &&
 						model.value.from > model.value.to

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/rating/rating-from-to-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/rating/rating-from-to-filter-value-field.vue
@@ -28,17 +28,17 @@ import { maxValue, requiredIf } from '@vuelidate/validators';
 import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+// both bounds start out unset
 type ModelValue = {
-	from: number;
-	to: number;
+	from: number | null;
+	to: number | null;
 };
-const model = defineModel<ModelValue>();
-if (!model.value) {
-	model.value = {
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
 		from: null,
 		to: null,
-	};
-}
+	}),
+});
 
 const emit = defineEmits<{
 	'update:invalid': [
@@ -56,7 +56,10 @@ const v$ = useVuelidate<{
 			from: {
 				required: requiredIf(() => !model.value.to),
 				maxValue: maxValue(
-					model?.value?.to && model.value.from > model.value.to
+					// `from` unset used to compare as `null > to`, i.e. false -> Infinity
+					model.value.to &&
+						model.value.from !== null &&
+						model.value.from > model.value.to
 						? model.value.to
 						: Infinity,
 				),

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/score/score-from-to-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/score/score-from-to-filter-value-field.vue
@@ -34,7 +34,6 @@ import { requiredIf } from '@vuelidate/validators';
 import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-// both bounds start out unset
 type ModelValue = {
 	from: number | null;
 	to: number | null;

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/score/score-from-to-filter-value-field.vue
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/components/score/score-from-to-filter-value-field.vue
@@ -34,17 +34,17 @@ import { requiredIf } from '@vuelidate/validators';
 import { computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+// both bounds start out unset
 type ModelValue = {
-	from: number;
-	to: number;
+	from: number | null;
+	to: number | null;
 };
-const model = defineModel<ModelValue>();
-if (!model.value) {
-	model.value = {
+const model = defineModel<ModelValue>({
+	default: (): ModelValue => ({
 		from: null,
 		to: null,
-	};
-}
+	}),
+});
 
 const props = withDefaults(
 	defineProps<{

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/composables/booleanFilterToolkit.ts
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/composables/booleanFilterToolkit.ts
@@ -23,8 +23,6 @@ export const usePrettifyBooleanValuePreview = (
 export const useBooleanFilterValueValidation = <
 	T extends BooleanFilterModelValue,
 >(
-	// `defineModel<T>()` without a default always widens to `T | undefined`, and the
-	// shared has-option field writes `null` when the selection is cleared.
 	model: ModelRef<T | null | undefined>,
 ) => {
 	const v$ = useVuelidate(

--- a/packages/ui-datalist/src/modules/filters/modules/filterConfig/composables/booleanFilterToolkit.ts
+++ b/packages/ui-datalist/src/modules/filters/modules/filterConfig/composables/booleanFilterToolkit.ts
@@ -23,12 +23,14 @@ export const usePrettifyBooleanValuePreview = (
 export const useBooleanFilterValueValidation = <
 	T extends BooleanFilterModelValue,
 >(
-	model: ModelRef<T>,
+	// `defineModel<T>()` without a default always widens to `T | undefined`, and the
+	// shared has-option field writes `null` when the selection is cleared.
+	model: ModelRef<T | null | undefined>,
 ) => {
 	const v$ = useVuelidate(
 		computed(() => ({
 			model: {
-				required: (v: T) => !(!v && v !== false),
+				required: (v: T | null | undefined) => !(!v && v !== false),
 			},
 		})),
 		{

--- a/packages/ui-datalist/src/modules/filters/scripts/utils.ts
+++ b/packages/ui-datalist/src/modules/filters/scripts/utils.ts
@@ -18,14 +18,18 @@ const isLabelSnapshotKey = (snapshotKey: string): boolean =>
 const isValueSnapshotKey = (snapshotKey: string): boolean =>
 	snapshotKey.includes('_val');
 
-export const filterNameFromSnapshotKey = (snapshotKey: string): FilterName => {
+export const filterNameFromSnapshotKey = (
+	snapshotKey: string,
+): FilterName | undefined => {
 	if (isLabelSnapshotKey(snapshotKey))
 		return filterLabelFromSnapshotKey(snapshotKey);
 	if (isValueSnapshotKey(snapshotKey))
 		return filterValueFromSnapshotKey(snapshotKey);
 };
 
-export const filterValuePropFromSnapshotKey = (snapshotKey: string): string => {
+export const filterValuePropFromSnapshotKey = (
+	snapshotKey: string,
+): string | undefined => {
 	if (isLabelSnapshotKey(snapshotKey)) return 'label';
 	if (isValueSnapshotKey(snapshotKey)) return 'value';
 };

--- a/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
+++ b/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
@@ -76,7 +76,7 @@ export const tableHeadersStoreBody = ({
 			}
 		});
 
-		const newOrder = [];
+		const newOrder: number[] = [];
 		for (const field of orderedFields) {
 			const indices = arrayFieldOrder.get(field);
 			const next = indices?.shift();

--- a/packages/ui-datalist/src/modules/pagination/createTablePaginationStore.ts
+++ b/packages/ui-datalist/src/modules/pagination/createTablePaginationStore.ts
@@ -30,7 +30,7 @@ export const tablePaginationStoreBody = () => {
 			value: page,
 			onRestore: async (restore, name) => {
 				const value = await restore(name);
-				const numValue = +value;
+				const numValue = Number(value);
 				if (numValue) page.value = numValue;
 			},
 		});
@@ -40,7 +40,7 @@ export const tablePaginationStoreBody = () => {
 			value: size,
 			onRestore: async (restore, name) => {
 				const value = await restore(name);
-				const numValue = +value;
+				const numValue = Number(value);
 				if (numValue) size.value = numValue;
 			},
 		});

--- a/packages/ui-datalist/src/modules/permissions-page/scripts/PermissionsApiModule.ts
+++ b/packages/ui-datalist/src/modules/permissions-page/scripts/PermissionsApiModule.ts
@@ -1,5 +1,4 @@
-import type { ApiModule } from '@webitel/ui-sdk/src/api/types/ApiModule';
-
+import type { TableApiModule } from '../../types/tableStore.types';
 import type {
 	PermissionEntity,
 	RawPermissionsApiModule,
@@ -13,9 +12,9 @@ import type {
  */
 export const PermissionsApiModule = (
 	rawApiModule: RawPermissionsApiModule,
-): ApiModule<PermissionEntity> => {
+): TableApiModule<PermissionEntity> => {
 	return {
 		getList: rawApiModule.getPermissionsList,
 		patch: rawApiModule.patchPermissions,
-	} as unknown as ApiModule<PermissionEntity>;
+	} as unknown as TableApiModule<PermissionEntity>;
 };

--- a/packages/ui-datalist/src/modules/permissions-page/stores/createPermissionsStore.ts
+++ b/packages/ui-datalist/src/modules/permissions-page/stores/createPermissionsStore.ts
@@ -81,7 +81,6 @@ export const permissionsStoreBody = (
 		try {
 			await (
 				config.apiModule.patch as unknown as (payload: {
-					// undefined until `initialize` has run
 					id: Id | undefined;
 					changes: PermissionsChange[];
 				}) => Promise<unknown>
@@ -120,7 +119,6 @@ export const permissionsStoreBody = (
 		error.value = null;
 		isLoading.value = false;
 		resetInfiniteScrollTableParamsToDefaults();
-		// undefined, matching the ref type and what `initialize` assigns
 		parentId.value = undefined;
 	};
 

--- a/packages/ui-datalist/src/modules/permissions-page/stores/createPermissionsStore.ts
+++ b/packages/ui-datalist/src/modules/permissions-page/stores/createPermissionsStore.ts
@@ -73,7 +73,7 @@ export const permissionsStoreBody = (
 	const parentId = ref<Id>();
 
 	const initialize: typeof tableStoreInitialize = (options) => {
-		parentId.value = options.parentId;
+		parentId.value = options?.parentId;
 		return tableStoreInitialize(options);
 	};
 
@@ -81,7 +81,8 @@ export const permissionsStoreBody = (
 		try {
 			await (
 				config.apiModule.patch as unknown as (payload: {
-					id: Id;
+					// undefined until `initialize` has run
+					id: Id | undefined;
 					changes: PermissionsChange[];
 				}) => Promise<unknown>
 			)({
@@ -119,7 +120,8 @@ export const permissionsStoreBody = (
 		error.value = null;
 		isLoading.value = false;
 		resetInfiniteScrollTableParamsToDefaults();
-		parentId.value = null;
+		// undefined, matching the ref type and what `initialize` assigns
+		parentId.value = undefined;
 	};
 
 	return {

--- a/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
+++ b/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
@@ -40,7 +40,8 @@ export interface PersistedPropertyConfig {
 		{ value, name },
 	) => Promise<void>;
 	onRestore?: (
-		restore: (name: string) => Promise<PersistableValue>,
+		// resolves `undefined` when no storage held a value for `name`
+		restore: (name: string) => Promise<PersistableValue | undefined>,
 		name: string,
 	) => Promise<void>;
 }

--- a/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
+++ b/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
@@ -24,7 +24,8 @@ export interface StorageLike {
 
 export interface PersistedPropertyConfig {
 	name: string;
-	// `null` while unset; some callers also pass a computed (see createTableHeadersStore)
+	// note: createTableHeadersStore passes a computed here, which the default
+	// restore path cannot write to
 	value: Ref<PersistableValue | null>;
 	storages?: PersistedStorageType | PersistedStorageType[];
 	storagePath?: string;

--- a/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
+++ b/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
@@ -24,7 +24,8 @@ export interface StorageLike {
 
 export interface PersistedPropertyConfig {
 	name: string;
-	value: Ref<PersistableValue>;
+	// `null` while unset; some callers also pass a computed (see createTableHeadersStore)
+	value: Ref<PersistableValue | null>;
 	storages?: PersistedStorageType | PersistedStorageType[];
 	storagePath?: string;
 	startWatchManually?: boolean;

--- a/packages/ui-datalist/src/modules/persist/useLocalStoragePersistedStorage.ts
+++ b/packages/ui-datalist/src/modules/persist/useLocalStoragePersistedStorage.ts
@@ -7,12 +7,10 @@ const makePath = (storagePath: string, key: string) => `${storagePath}/${key}`;
 export const useLocalStoragePersistedStorage = ({
 	storagePath = '',
 }: {
-	// optional at the call site — defaults to '' above
 	storagePath?: string;
 }): StorageLike => {
 	const getItem = async (key: string) => {
 		const value = localStorage.getItem(makePath(storagePath, key));
-		// was a try/catch relying on `.split` throwing on the null miss
 		if (value === null) return null;
 		return value.split(separator).join();
 	};

--- a/packages/ui-datalist/src/modules/persist/useLocalStoragePersistedStorage.ts
+++ b/packages/ui-datalist/src/modules/persist/useLocalStoragePersistedStorage.ts
@@ -7,15 +7,14 @@ const makePath = (storagePath: string, key: string) => `${storagePath}/${key}`;
 export const useLocalStoragePersistedStorage = ({
 	storagePath = '',
 }: {
-	storagePath: string;
+	// optional at the call site — defaults to '' above
+	storagePath?: string;
 }): StorageLike => {
 	const getItem = async (key: string) => {
 		const value = localStorage.getItem(makePath(storagePath, key));
-		try {
-			return value.split(separator).join();
-		} catch {
-			return value;
-		}
+		// was a try/catch relying on `.split` throwing on the null miss
+		if (value === null) return null;
+		return value.split(separator).join();
 	};
 
 	const setItem = async (key: string, inputValue: string | string[]) => {

--- a/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
+++ b/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
@@ -1,10 +1,11 @@
-import { watch } from 'vue';
+import { type WatchHandle, watch } from 'vue';
 
 import {
 	type PersistableValue,
 	type PersistedPropertyConfig,
 	type PersistedStorageController,
 	PersistedStorageType,
+	type StorageLike,
 } from './PersistedStorage.types';
 import { useLocalStoragePersistedStorage } from './useLocalStoragePersistedStorage';
 import { useRoutePersistedStorage } from './useRoutePersistedStorage';
@@ -20,25 +21,30 @@ export const usePersistedStorage = ({
 	onStore,
 	onRestore,
 }: PersistedPropertyConfig): PersistedStorageController => {
-	let unwatch = null;
+	let unwatch: WatchHandle | null = null;
 
-	const setItemFns = [];
-	const getItemFns: Array<(name: string) => Promise<PersistableValue>> = [];
-	const removeItemFns = [];
+	const setItemFns: StorageLike['setItem'][] = [];
+	const getItemFns: StorageLike['getItem'][] = [];
+	const removeItemFns: StorageLike['removeItem'][] = [];
 
+	// `null` entries are kept: callers below pick the first non-null value, so the
+	// per-storage misses have to stay in the list to preserve priority order.
 	const composedValueGetter = async (
 		name: string,
-	): Promise<PersistableValue[]> => {
+	): Promise<Array<PersistableValue | null>> => {
 		const settledResults = await Promise.allSettled(
 			getItemFns.map((getter) => getter(name)),
 		);
 
-		return settledResults.reduce((acc, result) => {
-			if (result.status === 'fulfilled') {
-				acc.push(result.value);
-			}
-			return acc;
-		}, [] as PersistableValue[]);
+		return settledResults.reduce(
+			(acc, result) => {
+				if (result.status === 'fulfilled') {
+					acc.push(result.value);
+				}
+				return acc;
+			},
+			[] as Array<PersistableValue | null>,
+		);
 	};
 
 	const storages = Array.isArray(configStorages)

--- a/packages/ui-datalist/src/modules/table/createTableStore.store.ts
+++ b/packages/ui-datalist/src/modules/table/createTableStore.store.ts
@@ -93,7 +93,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 
 	const dataList: Ref<Entity[]> = ref([]);
 	const selected: Ref<Entity[]> = ref([]);
-	const error = ref(null);
+	const error = ref<unknown>(null);
 	const isLoading = ref(false);
 
 	const updateSelected = (value: Entity[]) => {
@@ -125,7 +125,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 		try {
 			const { items, next } = await apiModule.getList(params);
 
-			dataList.value = items;
+			dataList.value = items ?? [];
 
 			/**
 			 * @author: @Oleksandr Palonnyi
@@ -134,7 +134,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 			 *
 			 * link to refactor task - https://webitel.atlassian.net/browse/WTEL-8599
 			 * */
-			updateSelected(filterSelected(items));
+			updateSelected(filterSelected(items ?? []));
 
 			$patchPaginationStore({
 				next,
@@ -169,7 +169,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 		try {
 			const { items, next } = await apiModule.getList(params);
 
-			dataList.value.push(...items);
+			dataList.value.push(...(items ?? []));
 			$patchPaginationStore({
 				next,
 			});
@@ -191,7 +191,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 		set(changes, path, value);
 
 		try {
-			await apiModule.patch({
+			await apiModule.patch?.({
 				changes,
 				parentId: parentId.value,
 				id: item.id,
@@ -211,7 +211,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 					_els,
 				];
 		const deleteEl = (el: Entity) => {
-			return apiModule.delete({
+			return apiModule.delete?.({
 				id: el.id,
 				etag: el.etag,
 				parentId: parentId.value,

--- a/packages/ui-datalist/src/modules/types/tableStore.types.ts
+++ b/packages/ui-datalist/src/modules/types/tableStore.types.ts
@@ -17,8 +17,16 @@ export type DatalistTableHeader = WtTableHeader & {
 
 export type TrackSelectedRowBy<T> = (row: T) => T;
 
+/**
+ * Every method on {@link ApiModule} is optional, but a table store cannot load
+ * anything without `getList`, so it is required here. `patch`/`delete` stay
+ * optional and are called defensively.
+ */
+export type TableApiModule<Entity> = ApiModule<Entity> &
+	Required<Pick<ApiModule<Entity>, 'getList'>>;
+
 export interface useTableStoreConfig<Entity> {
-	apiModule: ApiModule<Entity>;
+	apiModule: TableApiModule<Entity>;
 	headers: DatalistTableHeader[];
 	disablePersistence?: boolean | [];
 	storeType?: DatalistStoreProviderType;

--- a/src/api/types/ApiModule.ts
+++ b/src/api/types/ApiModule.ts
@@ -11,9 +11,11 @@ export interface ApiModule<Entity> {
 		next?: boolean;
 	}>;
 	get?: (params: {
-		itemId?: Id;
+		// `null` for consistency with update/patch below, and because card stores
+		// hold their id as `string | number | null`
+		itemId?: Id | null;
 		/** preferred over itemId */
-		id?: Id;
+		id?: Id | null;
 		parentId?: Id | null;
 	}) => Promise<Entity>;
 	add?: (params: {

--- a/src/api/types/ApiModule.ts
+++ b/src/api/types/ApiModule.ts
@@ -11,8 +11,6 @@ export interface ApiModule<Entity> {
 		next?: boolean;
 	}>;
 	get?: (params: {
-		// `null` for consistency with update/patch below, and because card stores
-		// hold their id as `string | number | null`
 		itemId?: Id | null;
 		/** preferred over itemId */
 		id?: Id | null;


### PR DESCRIPTION
Groundwork for enabling `strict` in `tsconfig.base.json`. **The flag itself is not flipped in this PR** — see *Why strict isn't on yet*.

Supersedes #1588, #1589, #1590, #1591 and #1592, which were a stacked chain; all seven commits are here and this targets `main` directly.

## Why

`strict: false` is set explicitly in `tsconfig.base.json`. Turning it on surfaces ~1300 distinct errors repo-wide, ~1030 of which are the `noImplicitAny` family (untyped params in `.ts`/`.vue`, plus untyped imports of the ~334 remaining `.js` sources in root `src`). So the rollout is staged: land everything in the `strict` family **except** `noImplicitAny` first — that is where the bug-catching value is — then lift `noImplicitAny` per package.

Under `strict` minus `noImplicitAny` the repo started at 279 errors. This PR clears 194 of them.

| unit | before | after |
|---|---|---|
| `api-services` | 40 | **0** ✅ |
| `styleguide` | 0 | **0** ✅ |
| `ui-chats` | 10 | **0** ✅ |
| `ui-datalist` | 183 | **43** |
| root `src` | 46 | **42** |
| **total** | **279** | **85** |

## Why strict isn't on yet

Flipping `strict` with 85 errors left would land a red baseline, and a permanently-red check trains everyone to ignore it. The flag goes in as the final commit of the series once the count reaches zero. Every fix here is verified green under the **current** config, so this is safe to merge on its own.

## Root causes fixed

Grouped by cause, not by file — each collapsed a cluster.

**Bare `[]` and `null` initialisers.** `skipKeys = []` in the snakeToCamel/camelToSnake transformers and in `objSnakeToCamel`/`objCamelToSnake` inferred `never[]`; four `string[]` annotations cleared 35 errors across `flow.ts`, `queues.ts`, `users.ts`, `contacts.ts`. Likewise `let unwatch = null`, `ref(null)` for `error`, and `newOrder = []`.

**`defineModel<T>()` without a default.** Ten filter fields declared `defineModel<ModelValue>()` and then populated it from `onMounted(initModel)` or an inline `if (!model.value)`, leaving the type `| undefined` and breaking every `model.value.x` and `{...model.value}` downstream — roughly 55 errors. Replaced with `defineModel<ModelValue>({ default: … })`, the form **already used by `case-service-filter-value-field.vue`**, which was the one component in that directory with zero errors. Pattern taken from the codebase, not invented.

**`null` sentinels typed as `| undefined`.** `ApiServicesConfig.eventBus`/`.i18n`, `DownloadFileOptions.mimetype`, the four `has-*` boolean models, `Filter.config`, and the score/rating `from`/`to` bounds. In each case the *type* was wrong, not the value.

**Signatures narrower than the data.** Every `ChatMessageFile` field is optional and `ChatMessageType.file` is optional, but `useChatMessageFile`, `isMediaType`, `chat-message-player`'s `type` prop and `getClientUsername` all claimed non-optional — while their bodies were *already* optional-chained. Same for `makeThisToRefs`'s `storeType`, which its own body defaults.

**`ApiModule` has every method optional**, but a table store cannot work without `getList`, and a card store cannot without `get`/`add`/`update`. Added a named `TableApiModule<Entity>` and the equivalent for cards. `patch`/`delete` remain genuinely optional and are now called with `?.` — an api module lacking them would previously have thrown a TypeError at the call site, so this is not a regression.

**Narrowing that does not reach.** `setConfig` dereferenced `conf.i18n` inside a `forEach`; `getFiltersList`/`reset` gated on `!isEmpty(include)`, which is not a type guard. Rebound to `const`s — narrowing on a const survives into a callback, which it does **not** for a parameter.

**`Map.get` promising a value.** `FiltersManager.getFilter`/`deleteFilter` declared `IFilter`. Corrected to `| undefined` on the class and the exported interface. Only two non-test callers exist and one already wrote `getFilter('search')?.value`.

## Four real defects the types found

1. **`FiltersManager.fromString` built entries keyed `"undefined"`.** `filterValuePropFromSnapshotKey` is two `if`s with no final return, so it yields `undefined` for a key that is neither `_lbl` nor `_val`. Both results were used directly as object keys, so an unrecognised snapshot key produced an entry literally keyed `"undefined"` containing an `"undefined"` value prop — which then reached `addFilter`. Now skipped.

2. **`notify.transformer.ts:15` called `apiServicesConfig.eventBus.$emit(...)` unguarded**, while the identical call 30 lines below has `?.`. It would throw for any host app using the notify transformer without configuring an event bus. Added `?.` to match.

3. **`PermissionsApiModule` was unsound.** Requiring `getList` made the checker reject `createPermissionsStore.ts:150`: the factory returns `{getList, patch}` but declared its return type as the fully-optional `ApiModule<PermissionEntity>` through an `as unknown as` cast, which was hiding it. Return type now says `TableApiModule<PermissionEntity>`.

4. **`chat-message-document.vue` produced `href="undefined"`.** `downloadDocument` assigned the optional `file.url` straight to `a.href`, so with no url the synthetic click navigated to a bogus relative path. Returns early now; `a.download` falls back to `''` so the browser derives the filename.

## Please review these

**Behaviour changes.** Three, all flagged deliberately:
- Removing `initModel` also removes an `update:modelValue` emit that fired on mount when the parent passed no value. The value emitted was the empty/cleared shape, so no filter state is lost, but a parent relying on that mount-time emit would no longer receive it. Inherent to typing the model correctly — the alternative was ~18 non-null assertions.
- `updateFilter` now throws a named error instead of `Cannot read properties of undefined (reading 'set')` one line later. Same control flow.
- The `downloadDocument` early return above.

**The only assertions in the series.** `FilterConfig` uses three definite-assignment assertions (`name!: FilterName`). `BaseFilterConfig` requires the fields, but concrete configs assign them as field initializers (`readonly name = FilterOption.Skill`) rather than through the constructor. Declaring them optional would break the `implements` contract and every consumer reading `.name`. If you want a different shape here — abstract base, required constructor params — say so and I'll rework it.

**One public type tightening.** `useTableStoreConfig.apiModule` now requires `getList`, so a consumer repo passing an api module without it will fail typecheck after the next `ui-datalist` release. Nothing in this workspace does — consumers pass whole api-services client modules — but it wants a release-note line. `ApiModule.get` also now accepts `Id | null` for `id`/`itemId`, matching `update`/`patch`, which already did.

## Two bugs left alone, needing your call

**Persisted sort restore has never worked.** `createTableHeadersStore` passes its `sort` **computed** as the persisted `value`, and `usePersistedStorage`'s default restore path does `value.value = restoredValue`. Writing to a computed is a Vue no-op (dev warning only). The fix is either making `sort` writable or giving that call an `onRestore` that routes into the underlying headers state — a behavioural decision, not a typing one.

**`ui-datalist` has no executing tests.** `FiltersManager.spec.ts` imports a missing `tests/config/config.js` so the suite fails to load; the package's `test:unit` is stubbed to `node -e "process.exit(0)"`; and `tsconfig.base.json` excludes `**/*.spec.ts`. So it is neither run nor typechecked — in the package where this PR makes the most changes. I updated the spec for the `getFilter` signature but left the harness alone. Root's 352 tests do pass.

## Not done

No `any`, no new `as` casts, no `@ts-ignore`/`@ts-expect-error`, no tsconfig loosening, no `exclude` additions. The three `!` in `FilterConfig` are the only assertions added.

## Verification

- `npm run typecheck` — clean in root and all four packages
- `npm run test:unit` — 352 passed, 3 skipped
- biome clean across root, ui-datalist, ui-chats, api-services (pre-existing `noExplicitAny` warnings in generated `src/gen/` untouched)

## Remaining 85, for follow-ups

- **ui-datalist 43** — `dynamic-filter-search.vue` (7) and `dynamic-filter-config-form.vue` (7), both optional props consumed as required; `filterConfig/components/index.ts` (3) `searchRecords` signature variance; `table-filters-panel.vue` (3); rest thin.
- **root `src` 42** — `accessStore.ts` (7), `useTableColumnDrag.ts` (5), remainder spread thin.