### PR TITLE
fix: restore filter presets without resetting filters [WTEL-10062]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
 			},
 			"devDependencies": {
 				"@biomejs/biome": "2.4.16",
+				"@pinia/testing": "^1.0.3",
 				"@regle/core": "^1.16.2",
 				"@tsconfig/node22": "^22.0.0",
 				"@types/deep-equal": "^1.0.4",
@@ -2409,6 +2410,19 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@pinia/testing": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@pinia/testing/-/testing-1.0.3.tgz",
+			"integrity": "sha512-g+qR49GNdI1Z8rZxKrQC3GN+LfnGTNf5Kk8Nz5Cz6mIGva5WRS+ffPXQfzhA0nu6TveWzPNYTjGl4nJqd3Cu9Q==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/posva"
+			},
+			"peerDependencies": {
+				"pinia": ">=3.0.4"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.16",
+		"@pinia/testing": "^1.0.3",
 		"@regle/core": "^1.16.2",
 		"@tsconfig/node22": "^22.0.0",
 		"@types/deep-equal": "^1.0.4",

--- a/packages/ui-datalist/src/modules/filter-presets/components/apply-preset/__tests__/apply-preset-action.spec.ts
+++ b/packages/ui-datalist/src/modules/filter-presets/components/apply-preset/__tests__/apply-preset-action.spec.ts
@@ -1,0 +1,91 @@
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { createPinia, defineStore, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+
+import { createFiltersManager } from '../../../../filters/classes/FiltersManager';
+import PresetQueryAPI from '../../../api/PresetQuery';
+import ApplyPresetAction from '../apply-preset-action.vue';
+
+vi.mock('../../../api/PresetQuery', () => ({
+	default: {
+		get: vi.fn(),
+		getList: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+	},
+}));
+
+const SNAPSHOT = '{"createdAt_val":"today"}';
+const CACHED_PRESET_ID = 7;
+
+/*
+Minimal stand-in for createFilterPresetsStore: apply-preset-action only needs
+these refs/actions, and this avoids dragging in the whole table store.
+ */
+const useTestPresetsStore = defineStore('test/presets', () => ({
+	dataList: ref([]),
+	error: ref(null),
+	isLoading: ref(false),
+	filtersManager: ref(createFiltersManager()),
+	presetId: ref<number | null>(CACHED_PRESET_ID),
+
+	loadDataList: vi.fn(),
+	initialize: vi.fn(),
+	updateSize: vi.fn(),
+	deleteEls: vi.fn(),
+	setupPresetPersistence: vi.fn(),
+}));
+
+const mountAction = ({ hasAnyFilters = false } = {}) =>
+	shallowMount(ApplyPresetAction, {
+		props: {
+			namespace: 'test',
+			presetsStore: useTestPresetsStore(),
+			filterConfigs: [],
+			hasAnyFilters,
+		},
+	});
+
+describe('ApplyPresetAction', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		setActivePinia(createPinia());
+
+		vi.mocked(PresetQueryAPI.get).mockResolvedValue({
+			id: CACHED_PRESET_ID,
+			preset: {
+				'filtersManager.toString': SNAPSHOT,
+			},
+		});
+	});
+
+	it('emits "restore" with the cached preset snapshot when no filters are applied', async () => {
+		const wrapper = mountAction();
+		await flushPromises();
+
+		expect(wrapper.emitted('restore')).toEqual([
+			[
+				SNAPSHOT,
+			],
+		]);
+	});
+
+	it('does not emit "apply" for a cached preset, so filters are not reset', async () => {
+		const wrapper = mountAction();
+		await flushPromises();
+
+		expect(wrapper.emitted('apply')).toBeUndefined();
+	});
+
+	it('skips restoring the cached preset when filters are already applied', async () => {
+		const wrapper = mountAction({
+			hasAnyFilters: true,
+		});
+		await flushPromises();
+
+		expect(PresetQueryAPI.get).not.toHaveBeenCalled();
+		expect(wrapper.emitted('restore')).toBeUndefined();
+		expect(wrapper.emitted('apply')).toBeUndefined();
+	});
+});

--- a/packages/ui-datalist/src/modules/filter-presets/components/apply-preset/__tests__/apply-preset-action.spec.ts
+++ b/packages/ui-datalist/src/modules/filter-presets/components/apply-preset/__tests__/apply-preset-action.spec.ts
@@ -1,5 +1,6 @@
+import { createTestingPinia } from '@pinia/testing';
 import { flushPromises, shallowMount } from '@vue/test-utils';
-import { createPinia, defineStore, setActivePinia } from 'pinia';
+import { defineStore } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 
@@ -18,39 +19,56 @@ vi.mock('../../../api/PresetQuery', () => ({
 
 const SNAPSHOT = '{"createdAt_val":"today"}';
 const CACHED_PRESET_ID = 7;
+const STORE_ID = 'test/presets';
 
 /*
-Minimal stand-in for createFilterPresetsStore: apply-preset-action only needs
-these refs/actions, and this avoids dragging in the whole table store.
+Only what apply-preset-action reads from the presets store – createTestingPinia
+stubs the actions, so none of them need bodies.
  */
-const useTestPresetsStore = defineStore('test/presets', () => ({
+const useTestPresetsStore = defineStore(STORE_ID, () => ({
 	dataList: ref([]),
 	error: ref(null),
 	isLoading: ref(false),
 	filtersManager: ref(createFiltersManager()),
-	presetId: ref<number | null>(CACHED_PRESET_ID),
+	presetId: ref<number | null>(null),
 
-	loadDataList: vi.fn(),
-	initialize: vi.fn(),
-	updateSize: vi.fn(),
-	deleteEls: vi.fn(),
-	setupPresetPersistence: vi.fn(),
+	loadDataList: () => {},
+	initialize: () => {},
+	updateSize: () => {},
+	deleteEls: () => {},
+	setupPresetPersistence: () => {},
 }));
 
-const mountAction = ({ hasAnyFilters = false } = {}) =>
-	shallowMount(ApplyPresetAction, {
+const mountAction = ({
+	hasAnyFilters = false,
+	presetId = CACHED_PRESET_ID,
+} = {}) => {
+	const pinia = createTestingPinia({
+		initialState: {
+			[STORE_ID]: {
+				presetId,
+			},
+		},
+	});
+
+	return shallowMount(ApplyPresetAction, {
 		props: {
 			namespace: 'test',
-			presetsStore: useTestPresetsStore(),
+			presetsStore: useTestPresetsStore(pinia),
 			filterConfigs: [],
 			hasAnyFilters,
 		},
+		global: {
+			plugins: [
+				pinia,
+			],
+		},
 	});
+};
 
 describe('ApplyPresetAction', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		setActivePinia(createPinia());
 
 		vi.mocked(PresetQueryAPI.get).mockResolvedValue({
 			id: CACHED_PRESET_ID,
@@ -87,5 +105,15 @@ describe('ApplyPresetAction', () => {
 		expect(PresetQueryAPI.get).not.toHaveBeenCalled();
 		expect(wrapper.emitted('restore')).toBeUndefined();
 		expect(wrapper.emitted('apply')).toBeUndefined();
+	});
+
+	it('does nothing when no preset is cached', async () => {
+		const wrapper = mountAction({
+			presetId: null,
+		});
+		await flushPromises();
+
+		expect(PresetQueryAPI.get).not.toHaveBeenCalled();
+		expect(wrapper.emitted('restore')).toBeUndefined();
 	});
 });

--- a/packages/ui-datalist/src/modules/filter-presets/components/apply-preset/apply-preset-action.vue
+++ b/packages/ui-datalist/src/modules/filter-presets/components/apply-preset/apply-preset-action.vue
@@ -99,10 +99,25 @@ const props = defineProps<{
 	namespace: string;
 	presetsStore: StoreGeneric;
 	filterConfigs: AnyFilterConfig[];
+	/**
+	 * @description
+	 * Filters the user has applied themselves. A cached preset is not restored
+	 * over them – the filters they arrived with win.
+	 */
+	hasAnyFilters?: boolean;
 }>();
 
 const emit = defineEmits<{
+	/**
+	 * user picked a preset in the popup – consumer resets filters first
+	 */
 	apply: [
+		string,
+	];
+	/**
+	 * cached preset re-applied on mount – consumer MUST NOT reset filters
+	 */
+	restore: [
 		string,
 	];
 }>();
@@ -253,12 +268,18 @@ const deletePreset = async (preset: EnginePresetQuery) => {
 
 const restorePresetById = async (id: number | null) => {
 	if (!id) return;
+	if (props.hasAnyFilters) return;
+
 	const presetData = await PresetQueryAPI.get({
 		id,
 	});
 	const filters = presetData?.preset?.['filtersManager.toString'];
 
-	if (filters) emit('apply', filters);
+	/* filters may have been restored from the route while the preset was being
+	   fetched, so re-check before overriding them */
+	if (props.hasAnyFilters) return;
+
+	if (filters) emit('restore', filters);
 };
 
 onMounted(async () => {

--- a/packages/ui-datalist/src/modules/filter-presets/components/apply-preset/apply-preset-action.vue
+++ b/packages/ui-datalist/src/modules/filter-presets/components/apply-preset/apply-preset-action.vue
@@ -268,6 +268,7 @@ const deletePreset = async (preset: EnginePresetQuery) => {
 
 const restorePresetById = async (id: number | null) => {
 	if (!id) return;
+	/* cheap exit – skips the request entirely */
 	if (props.hasAnyFilters) return;
 
 	const presetData = await PresetQueryAPI.get({

--- a/packages/ui-datalist/src/modules/filters/components/__tests__/table-filters-panel.spec.ts
+++ b/packages/ui-datalist/src/modules/filters/components/__tests__/table-filters-panel.spec.ts
@@ -1,6 +1,7 @@
+import { createTestingPinia } from '@pinia/testing';
 import { shallowMount } from '@vue/test-utils';
-import { createPinia, defineStore, setActivePinia } from 'pinia';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineStore } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import ApplyPresetAction from '../../../filter-presets/components/apply-preset/apply-preset-action.vue';
 import {
@@ -11,8 +12,9 @@ import { createFilterConfig } from '../../modules/filterConfig/classes/createFil
 import { FilterOption } from '../../modules/filterConfig/enums/FilterOption';
 import TableFiltersPanel from '../table-filters-panel.vue';
 
+/* the panel only ever calls resetPreset – createTestingPinia stubs it */
 const useTestPresetsStore = defineStore('test/presets', () => ({
-	resetPreset: vi.fn(),
+	resetPreset: () => {},
 }));
 
 /*
@@ -32,8 +34,10 @@ const filterOptions = [
 	FilterOption.Agent,
 ];
 
-const mountPanel = (filtersManager: IFiltersManager) =>
-	shallowMount(TableFiltersPanel, {
+const mountPanel = (filtersManager: IFiltersManager) => {
+	const pinia = createTestingPinia();
+
+	return shallowMount(TableFiltersPanel, {
 		props: {
 			filterOptions,
 			filtersManager,
@@ -41,11 +45,15 @@ const mountPanel = (filtersManager: IFiltersManager) =>
 			usePresetsStore: useTestPresetsStore,
 		},
 		global: {
+			plugins: [
+				pinia,
+			],
 			stubs: {
 				DynamicFilterPanelWrapper: DynamicFilterPanelWrapperStub,
 			},
 		},
 	});
+};
 
 const hasAnyFiltersOf = (filtersManager: IFiltersManager) =>
 	mountPanel(filtersManager)
@@ -56,7 +64,6 @@ describe('TableFiltersPanel preset restore gate', () => {
 	let filtersManager: IFiltersManager;
 
 	beforeEach(() => {
-		setActivePinia(createPinia());
 		filtersManager = createFiltersManager();
 	});
 

--- a/packages/ui-datalist/src/modules/filters/components/__tests__/table-filters-panel.spec.ts
+++ b/packages/ui-datalist/src/modules/filters/components/__tests__/table-filters-panel.spec.ts
@@ -1,0 +1,93 @@
+import { shallowMount } from '@vue/test-utils';
+import { createPinia, defineStore, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ApplyPresetAction from '../../../filter-presets/components/apply-preset/apply-preset-action.vue';
+import {
+	createFiltersManager,
+	type IFiltersManager,
+} from '../../classes/FiltersManager';
+import { createFilterConfig } from '../../modules/filterConfig/classes/createFilterConfig';
+import { FilterOption } from '../../modules/filterConfig/enums/FilterOption';
+import TableFiltersPanel from '../table-filters-panel.vue';
+
+const useTestPresetsStore = defineStore('test/presets', () => ({
+	resetPreset: vi.fn(),
+}));
+
+/*
+shallowMount stubs dynamic-filter-panel-wrapper, and stubs don't render slots –
+so apply-preset-action would never appear. This stub renders them.
+ */
+const DynamicFilterPanelWrapperStub = {
+	template: '<div><slot name="filters" /><slot name="actions" /></div>',
+};
+
+const filterOptions = [
+	/* same shape as cc-history: a seeded, non-removable default */
+	createFilterConfig({
+		name: FilterOption.CreatedAt,
+		notDeletable: true,
+	}),
+	FilterOption.Agent,
+];
+
+const mountPanel = (filtersManager: IFiltersManager) =>
+	shallowMount(TableFiltersPanel, {
+		props: {
+			filterOptions,
+			filtersManager,
+			presetNamespace: 'test',
+			usePresetsStore: useTestPresetsStore,
+		},
+		global: {
+			stubs: {
+				DynamicFilterPanelWrapper: DynamicFilterPanelWrapperStub,
+			},
+		},
+	});
+
+const hasAnyFiltersOf = (filtersManager: IFiltersManager) =>
+	mountPanel(filtersManager)
+		.findComponent(ApplyPresetAction)
+		.props('hasAnyFilters');
+
+describe('TableFiltersPanel preset restore gate', () => {
+	let filtersManager: IFiltersManager;
+
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		filtersManager = createFiltersManager();
+	});
+
+	it('reports no filters when nothing is applied', () => {
+		expect(hasAnyFiltersOf(filtersManager)).toBe(false);
+	});
+
+	it('ignores notDeletable filters, so a seeded default does not block restore', () => {
+		filtersManager.addFilter({
+			name: FilterOption.CreatedAt,
+			value: 'today',
+		});
+
+		expect(hasAnyFiltersOf(filtersManager)).toBe(false);
+	});
+
+	it('ignores the search filter', () => {
+		filtersManager.addFilter({
+			name: 'search',
+			value: 'test',
+		});
+
+		expect(hasAnyFiltersOf(filtersManager)).toBe(false);
+	});
+
+	it('reports filters when a deletable one is applied', () => {
+		filtersManager.addFilter({
+			name: FilterOption.Agent,
+			value: 1,
+		});
+
+		expect(hasAnyFiltersOf(filtersManager)).toBe(true);
+	});
+});

--- a/packages/ui-datalist/src/modules/filters/components/table-filters-panel.vue
+++ b/packages/ui-datalist/src/modules/filters/components/table-filters-panel.vue
@@ -38,9 +38,11 @@
         <apply-preset-action
           v-if="presetStore"
           :filter-configs="filterConfigs"
+          :has-any-filters="hasAnyFilters"
           :namespace="props.presetNamespace ?? ''"
           :presets-store="presetStore"
           @apply="emit('preset:apply', $event)"
+          @restore="emit('preset:restore', $event)"
         />
 
         <save-preset-action
@@ -164,6 +166,13 @@ const emit = defineEmits<{
 	'preset:apply': [
 		string,
 	];
+	/**
+	 * string == filtersManager.toString() snapshot of the preset cached in
+	 * localStorage. Handler must apply it WITHOUT resetting filters
+	 */
+	'preset:restore': [
+		string,
+	];
 	hide: [];
 }>();
 
@@ -201,6 +210,22 @@ const listSelectedFilters = computed(() => {
 		].filter(([key]) => allowedKeys.has(key)),
 	);
 });
+
+/**
+ * @description
+ * Filters applied by the user. `notDeletable` configs are skipped – they are
+ * seeded defaults, not a user choice, so they must not block preset restore.
+ */
+const hasAnyFilters = computed(() =>
+	[
+		...listSelectedFilters.value.keys(),
+	].some((name) => {
+		const filterConfig = filterConfigs.value.find(
+			(config) => String(config.name) === String(name),
+		);
+		return !filterConfig?.notDeletable;
+	}),
+);
 
 const presetStore = props.usePresetsStore ? props.usePresetsStore() : null;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,11 @@ export default (/*{ mode }*/) => {
 					__dirname,
 					'node_modules/axios',
 				),
+				/* packages/* carry their own pinia copy, but @pinia/testing is
+				   installed here. Pin every import to one ESM instance, otherwise
+				   createTestingPinia() sets the active pinia on a module the
+				   components under test don't read from */
+				pinia: resolve(__dirname, 'node_modules/pinia/dist/pinia.mjs'),
 			},
 			globals: true,
 			environment: 'happy-dom',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,6 +55,12 @@ export default (/*{ mode }*/) => {
 			alias: {
 				// vue: '@vue/compat',
 			},
+			/* packages/ui-datalist installs its own copy of the same pinia version.
+			   Two instances mean two "active pinia" registries, so a store created
+			   through one is invisible to components resolved through the other */
+			dedupe: [
+				'pinia',
+			],
 		},
 		plugins: [
 			tailwindcss(),
@@ -124,11 +130,6 @@ export default (/*{ mode }*/) => {
 					__dirname,
 					'node_modules/axios',
 				),
-				/* packages/* carry their own pinia copy, but @pinia/testing is
-				   installed here. Pin every import to one ESM instance, otherwise
-				   createTestingPinia() sets the active pinia on a module the
-				   components under test don't read from */
-				pinia: resolve(__dirname, 'node_modules/pinia/dist/pinia.mjs'),
 			},
 			globals: true,
 			environment: 'happy-dom',


### PR DESCRIPTION
## Description

`apply-preset-action` emitted a single `apply` event for two different situations:

1. the user picked a preset in the popup;
2. the preset id cached in `localStorage` was restored on mount (`onMounted` → `setupPresetPersistence()` → `restorePresetById()`).

Consumers handle `preset:apply` by resetting filters and then applying the snapshot — correct for (1), wrong for (2). So on mount the cached preset **wiped the filters the user arrived with**, including the ones `createTableFiltersStore.setupPersistence()` had just restored from the route, and then applied itself on top.

### What changed

- **`apply-preset-action.vue`** — new `restore` event; `restorePresetById()` emits it instead of `apply`. New `hasAnyFilters` prop: the cached preset is not restored at all while filters are applied. The gate is checked twice — before the request, and again after it resolves, because route persistence is not ordered against this component's `onMounted`.
- **`table-filters-panel.vue`** — forwards it as `preset:restore`, and computes `hasAnyFilters` from the filters it already tracks (`listSelectedFilters`, which excludes `search`), **skipping `notDeletable` configs**. Those are seeded defaults rather than a user choice — `cc-history` seeds `createdAt = Today` at setup, so counting it would block preset restore there permanently.
- `presetId` is left untouched when restore is skipped, so the preset stays remembered for a later visit that arrives without filters.
- `applySelectedPreset` and `handleResetFilters` are unchanged — picking a preset still resets, and the clear button still calls `resetPreset()`.

Also fixes the panel remount case: both consumers unmount the panel on `@hide`, so reopening it used to wipe manual filter edits. With the gate it now skips.

### Verification

- `npx vitest run packages/ui-datalist` → 3 files, 12 passed (2 new specs, 7 new cases)
- `npm run --prefix packages/ui-datalist typecheck` → exit 0
- `npm run --prefix packages/ui-datalist lint` → exit 0

New specs cover: cached preset emits `restore` (never `apply`) on mount; restore skipped entirely — no request — when filters are applied; and the gate itself (`false` for nothing applied / only `notDeletable` / only `search`, `true` for a deletable filter).

> [!IMPORTANT]
> Behaviourally breaking for the panel's event contract, and TypeScript will **not** catch it — an undeclared listener is attribute fallthrough, so a consumer wired only to `@preset:apply` still typechecks while `preset:restore` goes nowhere and the cached preset is never applied. It looks fine on F5 (route persistence repopulates) and only shows up when the URL has no `filters` param.
>
> Both preset consumers allow `^1.1.x`. Please bump **minor** and run `build:types` when publishing, and land the consumer PRs in the same window.

## Related Tasks

* [WTEL-10062](https://webitel.atlassian.net/browse/WTEL-10062)

## Related PR's / Issues

* webitel/crm — `fix/WTEL-10062/restore-preset-without-filters-reset`
* webitel/cc-history — `fix/WTEL-10062/restore-preset-without-filters-reset`

## Todos

- [x] Implementation
- [ ] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WTEL-10062]: https://webitel.atlassian.net/browse/WTEL-10062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ