### PR TITLE
fix: correct filter emit and delete confirmation types [WTEL-9942]

### DIFF
--- a/packages/ui-datalist/src/modules/filters/components/config/static-view/static-filter-field.vue
+++ b/packages/ui-datalist/src/modules/filters/components/config/static-view/static-filter-field.vue
@@ -44,8 +44,9 @@ const onValueChange = (value: FilterValue) => {
 	}
 
 	emit('update:filter', {
-		...props.filter,
+		name: props.filterConfig.name,
 		value,
+		label: props.filter?.label,
 	});
 };
 </script>

--- a/packages/ui-datalist/src/modules/filters/components/table-filters-panel.vue
+++ b/packages/ui-datalist/src/modules/filters/components/table-filters-panel.vue
@@ -76,7 +76,7 @@ import { computed } from 'vue';
 import { WebitelProtoDataField } from 'webitel-sdk';
 
 import { ApplyPresetAction, SavePresetAction } from '../../filter-presets';
-import { FilterData, IFilter } from '../classes/Filter';
+import { FilterInitParams, IFilter } from '../classes/Filter';
 import { IFiltersManager } from '../classes/FiltersManager';
 import { useFilterConfigsToolkit } from '../composables/useFilterConfigsToolkit';
 import { AnyFilterConfig } from '../modules/filterConfig/classes/FilterConfig';
@@ -151,10 +151,10 @@ const props = defineProps<Props>();
  */
 const emit = defineEmits<{
 	'filter:add': [
-		FilterData,
+		FilterInitParams,
 	];
 	'filter:update': [
-		FilterData,
+		FilterInitParams,
 	];
 	'filter:delete': [
 		IFilter,

--- a/packages/ui-datalist/src/modules/filters/components/types/Filter.types.ts
+++ b/packages/ui-datalist/src/modules/filters/components/types/Filter.types.ts
@@ -1,13 +1,9 @@
-import type {
-	FilterData,
-	FilterInitParams,
-	IFilter,
-} from '../../classes/Filter';
+import type { FilterInitParams, IFilter } from '../../classes/Filter';
 import type { AnyFilterConfig } from '../../modules/filterConfig';
 
 export interface FilterEmits {
 	'update:filter': [
-		FilterData,
+		FilterInitParams,
 	];
 	'delete:filter': [
 		IFilter,

--- a/src/modules/DeleteConfirmationPopup/composables/useDeleteConfirmationPopup.ts
+++ b/src/modules/DeleteConfirmationPopup/composables/useDeleteConfirmationPopup.ts
@@ -1,12 +1,19 @@
 import { ref } from 'vue';
 
-// eslint-disable-next-line import/prefer-default-export
+export type AskDeleteConfirmationParams = {
+	deleted?: unknown;
+	callback: () => unknown;
+};
+
 export const useDeleteConfirmationPopup = () => {
 	const isVisible = ref(false);
 	const deleteCount = ref(0);
-	const deleteCallback = ref(() => {});
+	const deleteCallback = ref<() => unknown>(() => {});
 
-	function askDeleteConfirmation({ deleted = undefined, callback }) {
+	function askDeleteConfirmation({
+		deleted,
+		callback,
+	}: AskDeleteConfirmationParams) {
 		if (Array.isArray(deleted)) deleteCount.value = deleted.length;
 		else deleteCount.value = 1;
 		isVisible.value = true;


### PR DESCRIPTION
## Summary
- Type `filter:add` / `filter:update` as `FilterInitParams` (includes `name`) so consumers can bind store `addFilter`/`updateFilter` without TS2322
- Convert `useDeleteConfirmationPopup` to TypeScript so `deleted` is `unknown` instead of inferred `undefined` from the JS default param
- Emit explicit `name`/`label` from static filter field updates (optional filter made spread `name` optional)

Unblocks `typecheck` in apps like `cc-history` and `crm`.

## Test plan
- [ ] `npm run typecheck` in `packages/ui-datalist` exits 0
- [ ] `npm run typecheck` / `build:types` for ui-sdk regenerates delete-confirmation types with `deleted?: unknown`
- [ ] After bump/link: `cc-history` and `crm` `npm run typecheck` stay green without node_modules patches


Made with [Cursor](https://cursor.com)