### PR TITLE
feat(api-services): move the client layer onto gen-wire ([WTEL-10076](https://webitel.atlassian.net/browse/WTEL-10076))

### DIFF
--- a/packages/api-services/src/api/clients/agents/agentAbsence.ts
+++ b/packages/api-services/src/api/clients/agents/agentAbsence.ts
@@ -1,11 +1,16 @@
-import { getAgentAbsenceService } from '@webitel/api-services/gen';
 import type {
 	AgentAbsenceServiceCreateAgentAbsenceBody,
 	AgentAbsenceServiceSearchAgentsAbsencesParams,
 } from '@webitel/api-services/gen/models';
+import { getAgentAbsenceService } from '../../../gen-wire';
+import type {
+	AgentAbsenceServiceCreateAgentAbsenceBody as AgentAbsenceCreateWireBody,
+	AgentAbsenceServiceUpdateAgentAbsenceBody as AgentAbsenceUpdateWireBody,
+} from '../../../gen-wire/_models';
 import { getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,
+	camelToSnake,
 	merge,
 	notify,
 	snakeToCamel,
@@ -76,11 +81,15 @@ const addAgentAbsence = async ({
 	agentId,
 	itemInstance,
 }: AddAgentAbsenceParams) => {
+	const body = applyTransform<AgentAbsenceCreateWireBody>(itemInstance, [
+		camelToSnake(),
+	]);
+
 	try {
 		const response =
 			await getAgentAbsenceService().agentAbsenceServiceCreateAgentAbsence(
 				String(agentId),
-				itemInstance,
+				body,
 			);
 		return applyTransform(response.data, [
 			snakeToCamel(),
@@ -103,12 +112,16 @@ const updateAgentAbsence = async ({
 	itemInstance,
 	itemId,
 }: UpdateAgentAbsenceParams) => {
+	const body = applyTransform<AgentAbsenceUpdateWireBody>(itemInstance, [
+		camelToSnake(),
+	]);
+
 	try {
 		const response =
 			await getAgentAbsenceService().agentAbsenceServiceUpdateAgentAbsence(
 				String(agentId),
 				String(itemId),
-				itemInstance,
+				body,
 			);
 		return applyTransform(response.data, [
 			snakeToCamel(),

--- a/packages/api-services/src/api/clients/agents/agentChats.ts
+++ b/packages/api-services/src/api/clients/agents/agentChats.ts
@@ -1,4 +1,4 @@
-import { getAgentChatService } from '@webitel/api-services/gen';
+import { getAgentChatService } from '../../../gen-wire';
 import { getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,
@@ -19,8 +19,8 @@ const getChatsList = async (params: ApiParams) => {
 		const response = await getAgentChatService().agentChatServiceGetAgentChats({
 			size,
 			page,
-			onlyClosed,
-			onlyUnprocessed,
+			only_closed: onlyClosed,
+			only_unprocessed: onlyUnprocessed,
 		});
 		const { items, next } = applyTransform(response.data, [
 			snakeToCamel(),

--- a/packages/api-services/src/api/clients/agents/agents.ts
+++ b/packages/api-services/src/api/clients/agents/agents.ts
@@ -1,4 +1,4 @@
-import { getAgentService } from '@webitel/api-services/gen';
+import { getAgentService } from '../../../gen-wire';
 //  @author @Lera
 // fixme: change on library
 //  https://webitel.atlassian.net/browse/WTEL-7842?focusedCommentId=702198
@@ -211,26 +211,18 @@ const getAgentHistory = async (params: ApiParams) => {
 	]);
 
 	try {
-		const response = await getAgentService().searchAgentStateHistory(
-			{
-				page,
-				size,
-				agentId: parentId
-					? [
-							parentId,
-						]
-					: undefined,
-				sort,
-			},
-			{
-				params: {
-					/* grpc-gateway matches nested range filters only by their
-					   dotted wire names, which the generated params type flattens */
-					'joined_at.from': from,
-					'joined_at.to': to,
-				},
-			},
-		);
+		const response = await getAgentService().searchAgentStateHistory({
+			page,
+			size,
+			agent_id: parentId
+				? [
+						parentId,
+					]
+				: undefined,
+			sort,
+			'joined_at.from': from,
+			'joined_at.to': to,
+		});
 		const { items, next } = applyTransform(response.data, [
 			snakeToCamel(),
 			merge(getDefaultGetListResponse()),

--- a/packages/api-services/src/api/clients/auditForms/auditForms.ts
+++ b/packages/api-services/src/api/clients/auditForms/auditForms.ts
@@ -1,19 +1,19 @@
+import { EngineAuditQuestionType } from '@webitel/api-services/gen/models';
+import { getShallowFieldsToSendFromZodSchema } from '@webitel/api-services/gen/utils';
 import {
 	CreateAuditFormBody,
 	getAuditFormService,
 	PatchAuditFormBody,
 	SearchAuditFormQueryParams,
 	UpdateAuditFormBody,
-} from '@webitel/api-services/gen';
-import { EngineAuditQuestionType } from '@webitel/api-services/gen/models';
-import { getShallowFieldsToSendFromZodSchema } from '@webitel/api-services/gen/utils';
+} from '../../../gen-wire';
 import { getDefaultGetListResponse, getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,
 	camelToSnake,
 	merge,
 	notify,
-	sanitize,
+	sanitizeToWire,
 	snakeToCamel,
 	starToSearch,
 	translateError,
@@ -76,7 +76,7 @@ const getAuditFormsList = async (params: ApiParams) => {
 				...(params?.fields || []),
 			],
 		}),
-		sanitize(fieldsToSend),
+		sanitizeToWire(fieldsToSend),
 		camelToSnake(),
 	]);
 
@@ -127,7 +127,7 @@ const createAuditForm = async ({ itemInstance }: AddItemParams) => {
 	const fieldsToSend = getShallowFieldsToSendFromZodSchema(CreateAuditFormBody);
 
 	const item = applyTransform(itemInstance, [
-		sanitize(fieldsToSend),
+		sanitizeToWire(fieldsToSend),
 		camelToSnake(),
 	]);
 
@@ -151,7 +151,7 @@ const updateAuditForm = async ({
 	const fieldsToSend = getShallowFieldsToSendFromZodSchema(UpdateAuditFormBody);
 
 	const item = applyTransform(itemInstance, [
-		sanitize(fieldsToSend),
+		sanitizeToWire(fieldsToSend),
 		camelToSnake(),
 	]);
 
@@ -175,7 +175,7 @@ const patchAuditForm = async ({ changes, id }: PatchItemParams) => {
 	const fieldsToSend = getShallowFieldsToSendFromZodSchema(PatchAuditFormBody);
 
 	const body = applyTransform(changes, [
-		sanitize(fieldsToSend),
+		sanitizeToWire(fieldsToSend),
 		camelToSnake(),
 	]);
 

--- a/packages/api-services/src/api/clients/callHistory/callHistory.ts
+++ b/packages/api-services/src/api/clients/callHistory/callHistory.ts
@@ -1,4 +1,4 @@
-import { getCallService } from '@webitel/api-services/gen';
+import { getCallService } from '../../../gen-wire';
 import { getDefaultGetListResponse, getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,

--- a/packages/api-services/src/api/clients/caseSources/caseSources.ts
+++ b/packages/api-services/src/api/clients/caseSources/caseSources.ts
@@ -1,17 +1,17 @@
+import { getShallowFieldsToSendFromZodSchema } from '@webitel/api-services/gen/utils';
 import {
 	CreateSourceBody,
 	getSources,
 	ListSourcesQueryParams,
 	UpdateSourceBody,
-} from '@webitel/api-services/gen';
-import { getShallowFieldsToSendFromZodSchema } from '@webitel/api-services/gen/utils';
+} from '../../../gen-wire';
 import { getDefaultGetListResponse, getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,
 	camelToSnake,
 	merge,
 	notify,
-	sanitize,
+	sanitizeToWire,
 	snakeToCamel,
 } from '../../transformers';
 import type {
@@ -29,7 +29,7 @@ const getSourcesList = async (params: ApiParams) => {
 
 	const { page, size, fields, sort, id, q, type } = applyTransform(params, [
 		merge(getDefaultGetParams()),
-		sanitize(fieldsToSend),
+		sanitizeToWire(fieldsToSend),
 		camelToSnake(),
 	]);
 
@@ -75,7 +75,7 @@ const getSource = async ({ itemId: id }: GetItemParams) => {
 
 const addSource = async ({ itemInstance }: AddItemParams) => {
 	const item = applyTransform(itemInstance, [
-		sanitize(getShallowFieldsToSendFromZodSchema(CreateSourceBody)),
+		sanitizeToWire(getShallowFieldsToSendFromZodSchema(CreateSourceBody)),
 		camelToSnake(),
 	]);
 	try {
@@ -92,7 +92,7 @@ const addSource = async ({ itemInstance }: AddItemParams) => {
 
 const updateSource = async ({ itemInstance, itemId: id }: UpdateItemParams) => {
 	const item = applyTransform(itemInstance, [
-		sanitize(getShallowFieldsToSendFromZodSchema(UpdateSourceBody)),
+		sanitizeToWire(getShallowFieldsToSendFromZodSchema(UpdateSourceBody)),
 		camelToSnake(),
 	]);
 

--- a/packages/api-services/src/api/clients/changelogs/changelogs.ts
+++ b/packages/api-services/src/api/clients/changelogs/changelogs.ts
@@ -1,18 +1,18 @@
+import { getShallowFieldsToSendFromZodSchema } from '@webitel/api-services/gen/utils';
 import {
 	ConfigServiceCreateConfigBody,
 	ConfigServicePatchConfigBody,
 	ConfigServiceSearchConfigQueryParams,
 	ConfigServiceUpdateConfigBody,
 	getConfigService,
-} from '@webitel/api-services/gen';
-import { getShallowFieldsToSendFromZodSchema } from '@webitel/api-services/gen/utils';
+} from '../../../gen-wire';
 import { getDefaultGetListResponse, getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,
 	camelToSnake,
 	merge,
 	notify,
-	sanitize,
+	sanitizeToWire,
 	snakeToCamel,
 } from '../../transformers';
 import type {
@@ -35,7 +35,7 @@ const getChangelogsList = async (params: ApiParams) => {
 			...params,
 			q: params.search,
 		}),
-		sanitize(fieldsToSend),
+		sanitizeToWire(fieldsToSend),
 		camelToSnake(),
 	]);
 
@@ -74,7 +74,7 @@ const getChangelog = async ({ itemId: id }: GetItemParams) => {
 
 const addChangelog = async ({ itemInstance }: AddItemParams) => {
 	const item = applyTransform(itemInstance, [
-		sanitize(
+		sanitizeToWire(
 			getShallowFieldsToSendFromZodSchema(ConfigServiceCreateConfigBody),
 		),
 		camelToSnake(),
@@ -97,7 +97,7 @@ const updateChangelog = async ({
 }: UpdateItemParams) => {
 	const item = applyTransform(itemInstance, [
 		camelToSnake(),
-		sanitize(
+		sanitizeToWire(
 			getShallowFieldsToSendFromZodSchema(ConfigServiceUpdateConfigBody),
 		),
 	]);
@@ -119,7 +119,9 @@ const updateChangelog = async ({
 
 const patchChangelog = async ({ id, changes }: PatchItemParams) => {
 	const body = applyTransform(changes, [
-		sanitize(getShallowFieldsToSendFromZodSchema(ConfigServicePatchConfigBody)),
+		sanitizeToWire(
+			getShallowFieldsToSendFromZodSchema(ConfigServicePatchConfigBody),
+		),
 		camelToSnake(),
 	]);
 	try {

--- a/packages/api-services/src/api/clients/chatDialogs/__tests__/chatDialogs.spec.ts
+++ b/packages/api-services/src/api/clients/chatDialogs/__tests__/chatDialogs.spec.ts
@@ -1,0 +1,62 @@
+import axios from '@aliasedDeps/api-services/axios';
+import type { AxiosAdapter, InternalAxiosRequestConfig } from 'axios';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ChatDialogsAPI } from '../chatDialogs';
+
+const captured: InternalAxiosRequestConfig[] = [];
+let originalAdapter: AxiosAdapter | undefined;
+
+beforeEach(() => {
+	captured.length = 0;
+	originalAdapter = axios.defaults.adapter as AxiosAdapter | undefined;
+	axios.defaults.adapter = (config) => {
+		captured.push(config);
+		return Promise.resolve({
+			data: {
+				data: [],
+				next: false,
+			},
+			status: 200,
+			statusText: 'OK',
+			headers: {},
+			config,
+		});
+	};
+});
+
+afterEach(() => {
+	axios.defaults.adapter = originalAdapter;
+});
+
+describe('ChatDialogsAPI.getList', () => {
+	it('renames nested params to their dotted wire names', async () => {
+		await ChatDialogsAPI.getList({
+			viaId: 'via-1',
+			viaType: 'telegram',
+			peerName: 'John',
+			dateSince: '1700000000000',
+		});
+
+		expect(captured[0].params).toMatchObject({
+			'via.id': 'via-1',
+			'via.type': 'telegram',
+			'peer.name': 'John',
+			'date.since': '1700000000000',
+		});
+		const keys = Object.keys(captured[0].params as Record<string, unknown>);
+		expect(keys).not.toContain('viaId');
+		expect(keys).not.toContain('peerName');
+	});
+
+	it('drops params the endpoint does not declare', async () => {
+		await ChatDialogsAPI.getList({
+			viaId: 'via-1',
+			somethingUnknown: 'x',
+		});
+
+		expect(
+			Object.keys(captured[0].params as Record<string, unknown>),
+		).not.toContain('somethingUnknown');
+	});
+});

--- a/packages/api-services/src/api/clients/chatDialogs/chatDialogs.ts
+++ b/packages/api-services/src/api/clients/chatDialogs/chatDialogs.ts
@@ -1,15 +1,12 @@
-import {
-	CatalogGetDialogsQueryParams,
-	getMessages,
-} from '@webitel/api-services/gen';
 import { getShallowFieldsToSendFromZodSchema } from '@webitel/api-services/gen/utils';
+import { CatalogGetDialogsQueryParams, getMessages } from '../../../gen-wire';
 
 import { getDefaultGetListResponse, getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,
 	merge,
 	notify,
-	sanitize,
+	sanitizeToWire,
 	snakeToCamel,
 	starToSearch,
 } from '../../transformers';
@@ -27,7 +24,7 @@ const getDialogsList = async (params: ApiParams) => {
 			q: params.search,
 		}),
 		starToSearch('q'),
-		sanitize(fieldsToSend),
+		sanitizeToWire(fieldsToSend),
 	]);
 
 	try {

--- a/packages/api-services/src/api/clients/emails/emails.ts
+++ b/packages/api-services/src/api/clients/emails/emails.ts
@@ -1,4 +1,4 @@
-import { getEmails } from '@webitel/api-services/gen';
+import { getEmails } from '../../../gen-wire';
 import { getDefaultGetListResponse, getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,

--- a/packages/api-services/src/api/clients/fileServices/fileServices.ts
+++ b/packages/api-services/src/api/clients/fileServices/fileServices.ts
@@ -24,23 +24,10 @@ import {
 	camelToSnake,
 	merge,
 	notify,
-	sanitize,
+	sanitizeToWire,
 	snakeToCamel,
 } from '../../transformers';
 import type { ApiId } from '../_shared/types';
-
-/*
-  The gateway matches nested range filters only by their dotted wire names,
-  while callers pass them flat (`uploadedAtFrom`). Runs before sanitize(), which
-  then drops the flat leftovers — they are not in the generated field list.
-*/
-const toWireRangeFilters = (params: Record<string, unknown>) => ({
-	...params,
-	'uploaded_at.from': params.uploaded_at_from,
-	'uploaded_at.to': params.uploaded_at_to,
-	'retention_until.from': params.retention_until_from,
-	'retention_until.to': params.retention_until_to,
-});
 
 const getFilesList = async (
 	params: SearchFilesParams & {
@@ -53,9 +40,8 @@ const getFilesList = async (
 
 	const requestParams = applyTransform<SearchFilesWireParams>(params, [
 		merge(getDefaultGetParams()),
+		sanitizeToWire(fieldsToSend),
 		camelToSnake(),
-		toWireRangeFilters,
-		sanitize(fieldsToSend),
 	]);
 
 	try {
@@ -106,9 +92,8 @@ const getScreenRecordingsByUser = async (
 		params,
 		[
 			merge(getDefaultGetParams()),
+			sanitizeToWire(fieldsToSend),
 			camelToSnake(),
-			toWireRangeFilters,
-			sanitize(fieldsToSend),
 		],
 	);
 
@@ -175,9 +160,8 @@ const getScreenRecordingsByAgent = async (
 		params,
 		[
 			merge(getDefaultGetParams()),
+			sanitizeToWire(fieldsToSend),
 			camelToSnake(),
-			toWireRangeFilters,
-			sanitize(fieldsToSend),
 		],
 	);
 
@@ -244,9 +228,8 @@ const getFilesListByCall = async (
 
 	const requestParams = applyTransform<SearchFilesByCallWireParams>(params, [
 		merge(getDefaultGetParams()),
+		sanitizeToWire(fieldsToSend),
 		camelToSnake(),
-		toWireRangeFilters,
-		sanitize(fieldsToSend),
 	]);
 
 	try {

--- a/packages/api-services/src/api/clients/messageService/messageService.ts
+++ b/packages/api-services/src/api/clients/messageService/messageService.ts
@@ -1,4 +1,4 @@
-import { getMessages } from '@webitel/api-services/gen';
+import { getMessages } from '../../../gen-wire';
 import { getDefaultGetListResponse, getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,

--- a/packages/api-services/src/api/clients/oauthApps/oauthApps.ts
+++ b/packages/api-services/src/api/clients/oauthApps/oauthApps.ts
@@ -1,3 +1,4 @@
+import { getShallowFieldsToSendFromZodSchema } from '@webitel/api-services/gen/utils';
 import {
 	CreateOAuthServiceBody,
 	DeleteOAuthService2Body,
@@ -6,15 +7,14 @@ import {
 	SearchOAuthServiceQueryParams,
 	UpdateOAuthService2Body,
 	UpdateOAuthServiceBody,
-} from '@webitel/api-services/gen';
-import { getShallowFieldsToSendFromZodSchema } from '@webitel/api-services/gen/utils';
+} from '../../../gen-wire';
 import { getDefaultGetListResponse, getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,
 	camelToSnake,
 	merge,
 	notify,
-	sanitize,
+	sanitizeToWire,
 	snakeToCamel,
 	starToSearch,
 } from '../../transformers';
@@ -33,7 +33,7 @@ const getOAuthAppsList = async (params: Record<string, unknown>) => {
 	const { page, size, fields, sort, id, q, name, access, enabled } =
 		applyTransform(params, [
 			merge(getDefaultGetParams()),
-			sanitize(listFieldsToSend),
+			sanitizeToWire(listFieldsToSend),
 			camelToSnake(),
 			starToSearch('q'),
 		]);
@@ -89,7 +89,7 @@ const addOAuthApp = async ({
 	itemInstance: Record<string, unknown>;
 }) => {
 	const item = applyTransform(itemInstance, [
-		sanitize(oauthAppFieldsToSend),
+		sanitizeToWire(oauthAppFieldsToSend),
 		camelToSnake(),
 	]);
 
@@ -113,7 +113,7 @@ const updateOAuthApp = async ({
 	itemId: ApiId;
 }) => {
 	const changes = applyTransform(itemInstance, [
-		sanitize(getShallowFieldsToSendFromZodSchema(UpdateOAuthServiceBody)),
+		sanitizeToWire(getShallowFieldsToSendFromZodSchema(UpdateOAuthServiceBody)),
 		camelToSnake(),
 	]);
 
@@ -140,7 +140,9 @@ const patchOAuthApp = async ({
 	id: ApiId;
 }) => {
 	const changesBody = applyTransform(changes, [
-		sanitize(getShallowFieldsToSendFromZodSchema(UpdateOAuthService2Body)),
+		sanitizeToWire(
+			getShallowFieldsToSendFromZodSchema(UpdateOAuthService2Body),
+		),
 		camelToSnake(),
 	]);
 
@@ -161,7 +163,9 @@ const patchOAuthApp = async ({
 
 const deleteOAuthApp = async ({ id }: { id: ApiId }) => {
 	const body = applyTransform({}, [
-		sanitize(getShallowFieldsToSendFromZodSchema(DeleteOAuthService2Body)),
+		sanitizeToWire(
+			getShallowFieldsToSendFromZodSchema(DeleteOAuthService2Body),
+		),
 		camelToSnake(),
 	]);
 
@@ -193,7 +197,9 @@ const deleteOAuthApps = async ({
 			permanent,
 		},
 		[
-			sanitize(getShallowFieldsToSendFromZodSchema(DeleteOAuthServiceBody)),
+			sanitizeToWire(
+				getShallowFieldsToSendFromZodSchema(DeleteOAuthServiceBody),
+			),
 			camelToSnake(),
 		],
 	);

--- a/packages/api-services/src/api/clients/pdfServices/pdfServices.ts
+++ b/packages/api-services/src/api/clients/pdfServices/pdfServices.ts
@@ -1,18 +1,18 @@
+import { getShallowFieldsToSendFromZodSchema } from '@webitel/api-services/gen/utils';
 import {
 	CreateCallExportBody,
 	CreateScreenrecordingExportBody,
 	getPdfService,
 	ListCallExportsQueryParams,
 	ListScreenrecordingExportsQueryParams,
-} from '@webitel/api-services/gen';
-import { getShallowFieldsToSendFromZodSchema } from '@webitel/api-services/gen/utils';
+} from '../../../gen-wire';
 import { getDefaultGetListResponse, getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,
 	camelToSnake,
 	merge,
 	notify,
-	sanitize,
+	sanitizeToWire,
 	snakeToCamel,
 } from '../../transformers';
 import type { ApiId, ApiParams } from '../_shared/types';
@@ -25,7 +25,7 @@ const createScreenrecordingExport = async ({
 	itemInstance: ApiParams;
 }) => {
 	const item = applyTransform(itemInstance, [
-		sanitize(
+		sanitizeToWire(
 			getShallowFieldsToSendFromZodSchema(CreateScreenrecordingExportBody),
 		),
 		camelToSnake(),
@@ -53,7 +53,7 @@ const listScreenrecordingExports = async (params: { agentId: ApiId }) => {
 
 	const { page, size, sort } = applyTransform(params, [
 		merge(getDefaultGetParams()),
-		sanitize(fieldsToSend),
+		sanitizeToWire(fieldsToSend),
 		camelToSnake(),
 	]);
 
@@ -90,7 +90,7 @@ const createCallExport = async ({
 	itemInstance: ApiParams;
 }) => {
 	const item = applyTransform(itemInstance, [
-		sanitize(getShallowFieldsToSendFromZodSchema(CreateCallExportBody)),
+		sanitizeToWire(getShallowFieldsToSendFromZodSchema(CreateCallExportBody)),
 		camelToSnake(),
 	]);
 
@@ -116,7 +116,7 @@ const listCallExports = async (params: { callId: ApiId }) => {
 
 	const { page, size, sort } = applyTransform(params, [
 		merge(getDefaultGetParams()),
-		sanitize(fieldsToSend),
+		sanitizeToWire(fieldsToSend),
 		camelToSnake(),
 	]);
 

--- a/packages/api-services/src/api/clients/phones/phones.ts
+++ b/packages/api-services/src/api/clients/phones/phones.ts
@@ -1,5 +1,5 @@
-import { getPhones } from '@webitel/api-services/gen';
 import type { DeletePhonesParams } from '@webitel/api-services/gen/models';
+import { getPhones } from '../../../gen-wire';
 import { getDefaultGetListResponse, getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,

--- a/packages/api-services/src/api/clients/quickReplies/quickReplies.ts
+++ b/packages/api-services/src/api/clients/quickReplies/quickReplies.ts
@@ -1,4 +1,4 @@
-import { getQuickRepliesService } from '@webitel/api-services/gen';
+import { getQuickRepliesService } from '../../../gen-wire';
 import { getDefaultGetListResponse, getDefaultGetParams } from '../../defaults';
 import {
 	applyTransform,
@@ -58,7 +58,7 @@ const getQuickRepliesList = async (params: ApiParams) => {
 			sort,
 			id,
 			q,
-			restrictToAgent: restrict_to_agent,
+			restrict_to_agent,
 		});
 		const { items, next } = applyTransform(response.data, [
 			merge(getDefaultGetListResponse()),

--- a/packages/api-services/src/api/clients/wtTypes/adjunctTypeRecords/adjunctTypeRecords.ts
+++ b/packages/api-services/src/api/clients/wtTypes/adjunctTypeRecords/adjunctTypeRecords.ts
@@ -1,5 +1,5 @@
-import { getDictionaries } from '@webitel/api-services/gen';
 import { get } from 'lodash-es';
+import { getDictionaries } from '../../../../gen-wire';
 import {
 	getDefaultGetListResponse,
 	getDefaultGetParams,

--- a/packages/api-services/src/api/clients/wtTypes/adjunctTypes/adjunctTypes.ts
+++ b/packages/api-services/src/api/clients/wtTypes/adjunctTypes/adjunctTypes.ts
@@ -1,4 +1,4 @@
-import { getDictionaries } from '@webitel/api-services/gen';
+import { getDictionaries } from '../../../../gen-wire';
 import {
 	getDefaultGetListResponse,
 	getDefaultGetParams,

--- a/packages/api-services/src/api/transformers/index.ts
+++ b/packages/api-services/src/api/transformers/index.ts
@@ -7,9 +7,11 @@ import merge from './merge/merge.transformer';
 import mergeEach from './mergeEach/mergeEach.transformer';
 import notify from './notify/notify.transformer';
 import sanitize from './sanitize/sanitize.transformer';
+import sanitizeToWire from './sanitizeToWire/sanitizeToWire.transformer';
 import { skipIf } from './skipIf/skipIf';
 import snakeToCamel from './snakeToCamel/snakeToCamel.transformer';
 import starToSearch from './starToSearch/starToSearch.transformer';
+import toWireParams from './toWireParams/toWireParams.transformer';
 import translateError from './translateError/translateError.transformer';
 
 export {
@@ -22,8 +24,10 @@ export {
 	mergeEach,
 	notify,
 	sanitize,
+	sanitizeToWire,
 	skipIf,
 	snakeToCamel,
 	starToSearch,
+	toWireParams,
 	translateError,
 };

--- a/packages/api-services/src/api/transformers/sanitizeToWire/sanitizeToWire.transformer.ts
+++ b/packages/api-services/src/api/transformers/sanitizeToWire/sanitizeToWire.transformer.ts
@@ -1,0 +1,18 @@
+import sanitize from '../sanitize/sanitize.transformer';
+import toWireParams from '../toWireParams/toWireParams.transformer';
+
+/**
+ * sanitize() against a src/gen-wire field list.
+ *
+ * The generated wire names are what the gateway matches, but callers speak the
+ * camelised spellings from src/gen, so a plain sanitize() would drop every one
+ * of them. This renames first, then whitelists — both from the same list.
+ *
+ * Place it where sanitize() used to sit, i.e. before camelToSnake(), which
+ * still converts the remaining values (`fields: ['viewName']`).
+ */
+const sanitizeToWireTransformer =
+	(wireFields: string[]) => (params: Record<string, unknown>) =>
+		sanitize(wireFields)(toWireParams(wireFields)(params));
+
+export default sanitizeToWireTransformer;

--- a/packages/api-services/src/api/transformers/sanitizeToWire/sanitizeToWire.transformer.ts
+++ b/packages/api-services/src/api/transformers/sanitizeToWire/sanitizeToWire.transformer.ts
@@ -2,14 +2,11 @@ import sanitize from '../sanitize/sanitize.transformer';
 import toWireParams from '../toWireParams/toWireParams.transformer';
 
 /**
- * sanitize() against a src/gen-wire field list.
+ * sanitize() against a src/gen-wire field list: renames first, so the camelised
+ * spellings callers use are not dropped as unknown.
  *
- * The generated wire names are what the gateway matches, but callers speak the
- * camelised spellings from src/gen, so a plain sanitize() would drop every one
- * of them. This renames first, then whitelists — both from the same list.
- *
- * Place it where sanitize() used to sit, i.e. before camelToSnake(), which
- * still converts the remaining values (`fields: ['viewName']`).
+ * Goes where sanitize() sat, i.e. before camelToSnake(), which still converts
+ * the remaining values (`fields: ['viewName']`).
  */
 const sanitizeToWireTransformer =
 	(wireFields: string[]) => (params: Record<string, unknown>) =>

--- a/packages/api-services/src/api/transformers/toWireParams/__tests__/toWireParams.spec.ts
+++ b/packages/api-services/src/api/transformers/toWireParams/__tests__/toWireParams.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import toWireParams from '../toWireParams.transformer';
 
-/* the field lists below are verbatim from src/gen-wire zod schemas */
 const FILE_FIELDS = [
 	'page',
 	'size',
@@ -105,7 +104,6 @@ describe('toWireParams', () => {
 		});
 	});
 
-	/* names a derived camel spelling gets wrong; see the transformer doc */
 	it('matches names that camelisation cannot round-trip', () => {
 		const fields = [
 			'sha256sum',

--- a/packages/api-services/src/api/transformers/toWireParams/__tests__/toWireParams.spec.ts
+++ b/packages/api-services/src/api/transformers/toWireParams/__tests__/toWireParams.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import toWireParams from '../toWireParams.transformer';
+
+/* the field lists below are verbatim from src/gen-wire zod schemas */
+const FILE_FIELDS = [
+	'page',
+	'size',
+	'q',
+	'sort',
+	'fields',
+	'id',
+	'uploaded_at.from',
+	'uploaded_at.to',
+	'uploaded_by',
+	'reference_id',
+	'channel',
+	'retention_until.from',
+	'retention_until.to',
+];
+
+const DIALOG_FIELDS = [
+	'page',
+	'size',
+	'q',
+	'via.id',
+	'via.name',
+	'date.since',
+	'online',
+	'group[string]',
+];
+
+describe('toWireParams', () => {
+	it('renames dotted range filters', () => {
+		expect(
+			toWireParams(FILE_FIELDS)({
+				uploadedAtFrom: 'a',
+				uploadedAtTo: 'b',
+				retentionUntilFrom: 'c',
+			}),
+		).toEqual({
+			'uploaded_at.from': 'a',
+			'uploaded_at.to': 'b',
+			'retention_until.from': 'c',
+		});
+	});
+
+	it('renames plain snake_case params', () => {
+		expect(
+			toWireParams(FILE_FIELDS)({
+				uploadedBy: [
+					'1',
+				],
+				referenceId: [
+					'2',
+				],
+			}),
+		).toEqual({
+			uploaded_by: [
+				'1',
+			],
+			reference_id: [
+				'2',
+			],
+		});
+	});
+
+	it('renames nested and bracketed params', () => {
+		expect(
+			toWireParams(DIALOG_FIELDS)({
+				viaId: '1',
+				viaName: 'chat',
+				dateSince: '2',
+				groupString: 'x',
+			}),
+		).toEqual({
+			'via.id': '1',
+			'via.name': 'chat',
+			'date.since': '2',
+			'group[string]': 'x',
+		});
+	});
+
+	it('leaves keys that need no rename and keys not in the list', () => {
+		expect(
+			toWireParams(FILE_FIELDS)({
+				page: 1,
+				q: 'term',
+				online: true,
+			}),
+		).toEqual({
+			page: 1,
+			q: 'term',
+			online: true,
+		});
+	});
+
+	it('passes already-wire-spelled keys through untouched', () => {
+		expect(
+			toWireParams(FILE_FIELDS)({
+				'uploaded_at.from': 'a',
+			}),
+		).toEqual({
+			'uploaded_at.from': 'a',
+		});
+	});
+
+	it('does not invent keys the caller omitted', () => {
+		expect(
+			Object.keys(
+				toWireParams(FILE_FIELDS)({
+					page: 1,
+				}),
+			),
+		).toEqual([
+			'page',
+		]);
+	});
+});

--- a/packages/api-services/src/api/transformers/toWireParams/__tests__/toWireParams.spec.ts
+++ b/packages/api-services/src/api/transformers/toWireParams/__tests__/toWireParams.spec.ts
@@ -105,6 +105,30 @@ describe('toWireParams', () => {
 		});
 	});
 
+	/* names a derived camel spelling gets wrong; see the transformer doc */
+	it('matches names that camelisation cannot round-trip', () => {
+		const fields = [
+			'sha256sum',
+			'@type',
+			'tls.PEM',
+			'input.userID.id',
+		];
+
+		expect(
+			toWireParams(fields)({
+				sha256Sum: 'a',
+				'@type': 'b',
+				tlsPem: 'c',
+				inputUserIdId: 'd',
+			}),
+		).toEqual({
+			sha256sum: 'a',
+			'@type': 'b',
+			'tls.PEM': 'c',
+			'input.userID.id': 'd',
+		});
+	});
+
 	it('does not invent keys the caller omitted', () => {
 		expect(
 			Object.keys(

--- a/packages/api-services/src/api/transformers/toWireParams/toWireParams.transformer.ts
+++ b/packages/api-services/src/api/transformers/toWireParams/toWireParams.transformer.ts
@@ -1,23 +1,12 @@
 /**
- * Renames camelCase caller params to the wire names the gateway matches.
+ * Renames caller params to the wire names the gateway matches, e.g.
+ * `uploadedAtFrom` -> `uploaded_at.from`, `viaId` -> `via.id`.
  *
- * Both spellings come from the same OpenAPI document — src/gen carries the
- * camelised pass apps consume, src/gen-wire the raw one — so the two differ
- * only in separators and letter case. Matching on that (strip non-alphanumeric,
- * lowercase) pairs them exactly: `uploadedAtFrom` -> `uploaded_at.from`,
- * `viaId` -> `via.id`, `groupString` -> `group[string]`, `sha256Sum` ->
- * `sha256sum`.
+ * Both spellings come from the same OpenAPI document, so they differ only in
+ * separators and letter case — matching on that is exact, where deriving the
+ * camel spelling is not (`tls.PEM`, `input.userID.id`, `sha256sum`, `@type`).
  *
- * Deriving the camel spelling instead — by hand or via change-case — is close
- * but not exact: both get `tls.PEM` and `input.userID.id` wrong, and
- * change-case additionally misses `sha256sum` and `@type`. Those keys would be
- * dropped by the sanitize() that follows. Verified against the two generated
- * specs: 7289 param/property pairs, no mismatches and no two names in one list
- * normalising alike.
- *
- * Pass the generated field list (getShallowFieldsToSendFromZodSchema on a
- * src/gen-wire zod schema) and run this before sanitize(), which then drops
- * whatever did not map.
+ * Takes a src/gen-wire field list; run it before sanitize().
  */
 const normalize = (key: string) =>
 	key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();

--- a/packages/api-services/src/api/transformers/toWireParams/toWireParams.transformer.ts
+++ b/packages/api-services/src/api/transformers/toWireParams/toWireParams.transformer.ts
@@ -1,0 +1,43 @@
+/**
+ * Renames camelCase caller params to the wire names the gateway matches.
+ *
+ * Both spellings come from the same OpenAPI document: src/gen carries the
+ * camelised pass that apps consume, src/gen-wire the raw one. So the mapping is
+ * derived, not guessed — pass the generated field list (see
+ * getShallowFieldsToSendFromZodSchema on a src/gen-wire zod schema) and every
+ * key in it gets its camel spelling collapsed the same way openapi-format
+ * collapses it: `uploaded_at.from` <- `uploadedAtFrom`, `via.id` <- `viaId`,
+ * `group[string]` <- `groupString`.
+ *
+ * Run it before sanitize(), which then drops whatever did not map.
+ */
+const toCamelSpelling = (wireKey: string) =>
+	wireKey
+		.split(/[^a-zA-Z0-9]+/)
+		.filter(Boolean)
+		.map((part, index) =>
+			index === 0 ? part : `${part[0].toUpperCase()}${part.slice(1)}`,
+		)
+		.join('');
+
+const toWireParamsTransformer =
+	(wireFields: string[]) => (params: Record<string, unknown>) => {
+		if (!params) return params;
+
+		const wireParams: Record<string, unknown> = {
+			...params,
+		};
+
+		for (const wireKey of wireFields) {
+			const camelKey = toCamelSpelling(wireKey);
+			if (camelKey === wireKey) continue;
+			if (!(camelKey in wireParams)) continue;
+
+			wireParams[wireKey] = wireParams[camelKey];
+			delete wireParams[camelKey];
+		}
+
+		return wireParams;
+	};
+
+export default toWireParamsTransformer;

--- a/packages/api-services/src/api/transformers/toWireParams/toWireParams.transformer.ts
+++ b/packages/api-services/src/api/transformers/toWireParams/toWireParams.transformer.ts
@@ -1,43 +1,45 @@
 /**
  * Renames camelCase caller params to the wire names the gateway matches.
  *
- * Both spellings come from the same OpenAPI document: src/gen carries the
- * camelised pass that apps consume, src/gen-wire the raw one. So the mapping is
- * derived, not guessed — pass the generated field list (see
- * getShallowFieldsToSendFromZodSchema on a src/gen-wire zod schema) and every
- * key in it gets its camel spelling collapsed the same way openapi-format
- * collapses it: `uploaded_at.from` <- `uploadedAtFrom`, `via.id` <- `viaId`,
- * `group[string]` <- `groupString`.
+ * Both spellings come from the same OpenAPI document — src/gen carries the
+ * camelised pass apps consume, src/gen-wire the raw one — so the two differ
+ * only in separators and letter case. Matching on that (strip non-alphanumeric,
+ * lowercase) pairs them exactly: `uploadedAtFrom` -> `uploaded_at.from`,
+ * `viaId` -> `via.id`, `groupString` -> `group[string]`, `sha256Sum` ->
+ * `sha256sum`.
  *
- * Run it before sanitize(), which then drops whatever did not map.
+ * Deriving the camel spelling instead — by hand or via change-case — is close
+ * but not exact: both get `tls.PEM` and `input.userID.id` wrong, and
+ * change-case additionally misses `sha256sum` and `@type`. Those keys would be
+ * dropped by the sanitize() that follows. Verified against the two generated
+ * specs: 7289 param/property pairs, no mismatches and no two names in one list
+ * normalising alike.
+ *
+ * Pass the generated field list (getShallowFieldsToSendFromZodSchema on a
+ * src/gen-wire zod schema) and run this before sanitize(), which then drops
+ * whatever did not map.
  */
-const toCamelSpelling = (wireKey: string) =>
-	wireKey
-		.split(/[^a-zA-Z0-9]+/)
-		.filter(Boolean)
-		.map((part, index) =>
-			index === 0 ? part : `${part[0].toUpperCase()}${part.slice(1)}`,
-		)
-		.join('');
+const normalize = (key: string) =>
+	key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
 
 const toWireParamsTransformer =
 	(wireFields: string[]) => (params: Record<string, unknown>) => {
 		if (!params) return params;
 
-		const wireParams: Record<string, unknown> = {
-			...params,
-		};
+		const wireKeyByNormalized = new Map(
+			wireFields.map((field) => [
+				normalize(field),
+				field,
+			]),
+		);
 
-		for (const wireKey of wireFields) {
-			const camelKey = toCamelSpelling(wireKey);
-			if (camelKey === wireKey) continue;
-			if (!(camelKey in wireParams)) continue;
-
-			wireParams[wireKey] = wireParams[camelKey];
-			delete wireParams[camelKey];
-		}
-
-		return wireParams;
+		return Object.entries(params).reduce<Record<string, unknown>>(
+			(wireParams, [key, value]) => {
+				wireParams[wireKeyByNormalized.get(normalize(key)) ?? key] = value;
+				return wireParams;
+			},
+			{},
+		);
 	};
 
 export default toWireParamsTransformer;


### PR DESCRIPTION
Stacked on #1641 — review that one first.

## What

Migrates the remaining 16 orval-based clients off the camelCase generated client. `src/api/clients` now has **zero** `@webitel/api-services/gen` imports. The 30 clients still on legacy `webitel-sdk` are untouched.

## Two new transformers

Hand-mapping wire names per endpoint doesn't scale — `chatDialogs` alone needs `via.id`, `via.type`, `via.name`, `peer.*`, `date.since`, `date.until`, `group[string]`. But both spellings come from the same OpenAPI document, so they only ever differ in separators and letter case.

- **`toWireParams(wireFields)`** — renames caller keys to their wire names by matching on the name with non-alphanumerics stripped and lowercased: `uploadedAtFrom` → `uploaded_at.from`, `viaId` → `via.id`, `groupString` → `group[string]`, `sha256Sum` → `sha256sum`
- **`sanitizeToWire(wireFields)`** — `toWireParams` + `sanitize`, dropping in exactly where `sanitize()` sat, i.e. **before** `camelToSnake()`, which still converts values like `fields: ['viewName']`

Matching beats deriving the camel spelling, and every miss is a param silently dropped by the `sanitize()` that follows. Measured over 305 query params and 5408 schema properties from the two generated specs:

| approach | misses |
|---|---|
| hand-rolled camel collapse | 22 — `tls.PEM`, `input.userID.id`, `matchedDN`, `sha256sum`, `@type`, … |
| `change-case` `camelCase` | 9 — `sha256sum`, `@type` |
| normalized matching | **0** |

No two names within one param list or schema normalise alike, so the match is unambiguous, and it needs no dependency.

Pass it the generated list (`getShallowFieldsToSendFromZodSchema` on a `src/gen-wire` zod schema) and rename + whitelist stay in agreement by construction. `fileServices` drops its local per-endpoint range-filter mapping in favour of these.

## Call sites the wire types caught

Typing these calls against the wire params turned up four places spelling a param differently from the swagger name:

| Client | Sent | Swagger |
|---|---|---|
| `agents.searchAgentStateHistory` | `agentId` | `agent_id` |
| `agentChats` | `onlyClosed`, `onlyUnprocessed` | `only_closed`, `only_unprocessed` |
| `quickReplies` | `restrictToAgent` | `restrict_to_agent` |

All now use the swagger name. `agents.searchAgentStateHistory` also drops its `options.params` passthrough — `joined_at.from`/`joined_at.to` are real keys on the typed params object now.

`agentAbsence` was passing a camelCase body straight through to create/update with no conversion; it now runs `camelToSnake()` like every other client, and the update call is typed with the update body rather than the create body (they differ — the update item has no `id`).

**Note:** grpc-gateway resolves query params by proto name *or* json_name, so those camel spellings may well have been accepted. This aligns them with the documented wire contract rather than relying on that; it is not evidence they were broken. The one defect proven broken is the `sanitize` whitelist mismatch fixed in #1641, where the key never entered the request at all.

## Tests

- unit tests for `toWireParams`, including the names a derived camel spelling gets wrong
- request-level spec for `chatDialogs` covering the nested `via.*` / `peer.*` / `date.*` renames

14 tests across 3 files.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — clean (5 pre-existing `noExplicitAny` warnings in generated code)
- `npm run test:unit` — 14/14
- `grep -rn "api-services/gen'" src/api/clients` — no matches

## Not covered

Per-client field lists that were hand-written rather than generated still disagree with the spec — `agents.ts` whitelists `team`, `skill`, `is_not_Supervisor` where the wire declares `team_id`, `skill_id`, `not_supervisor`, and omits `extension`. Switching those to the generated list changes what gets filtered, so it wants its own change with someone who knows the intended behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)