### PR TITLE
fix(ui-datalist): republish table store state into route query on registry re-mount [WTEL-10093]

### DIFF
--- a/packages/ui-datalist/src/modules/filters/__tests__/createTableFiltersStore.spec.ts
+++ b/packages/ui-datalist/src/modules/filters/__tests__/createTableFiltersStore.spec.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createApp } from 'vue';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+
+import { tableFiltersStoreBody } from '../createTableFiltersStore';
+
+const routes = [
+	{
+		path: '/cases',
+		name: 'cases',
+		component: {
+			template: '<div />',
+		},
+	},
+];
+
+const namespace = 'cases';
+
+describe('tableFiltersStoreBody', () => {
+	let router: Router;
+	let runWithRouter: <T>(fn: () => T) => T;
+
+	beforeEach(async () => {
+		localStorage.clear();
+
+		router = createRouter({
+			history: createMemoryHistory(),
+			routes,
+		});
+
+		const app = createApp({});
+		app.use(router);
+
+		await router.push('/cases');
+		await router.isReady();
+
+		runWithRouter = (fn) => app.runWithContext(fn);
+	});
+
+	const setUpStore = async () => {
+		const store = tableFiltersStoreBody(namespace);
+		await runWithRouter(() => store.setupPersistence());
+		return store;
+	};
+
+	it('starts with no filters', () => {
+		const store = tableFiltersStoreBody(namespace);
+
+		expect(store.filtersList.value).toEqual([]);
+	});
+
+	it('adds, updates and deletes a filter', () => {
+		const store = tableFiltersStoreBody(namespace);
+
+		store.addFilter({
+			name: 'status',
+			value: 'open',
+		});
+		expect(store.hasFilter('status')).toBe(true);
+
+		store.updateFilter({
+			name: 'status',
+			value: 'closed',
+		});
+		expect(store.filtersManager.getFilter('status')?.value).toBe('closed');
+
+		store.deleteFilter({
+			name: 'status',
+		});
+		expect(store.hasFilter('status')).toBe(false);
+	});
+
+	it('keeps searchMode', () => {
+		const store = tableFiltersStoreBody(namespace);
+
+		store.updateSearchMode('subject');
+
+		expect(store.searchMode.value).toBe('subject');
+	});
+
+	describe('persistence', () => {
+		it('restores filters from the route query', async () => {
+			await router.push({
+				name: 'cases',
+				query: {
+					filters: JSON.stringify({
+						status_val: 'open',
+					}),
+				},
+			});
+
+			const store = await setUpStore();
+
+			expect(store.filtersManager.getFilter('status')?.value).toBe('open');
+		});
+
+		it('writes an added filter into the route query', async () => {
+			const store = await setUpStore();
+
+			store.addFilter({
+				name: 'status',
+				value: 'open',
+			});
+			await new Promise((resolve) => setTimeout(resolve));
+
+			expect(router.currentRoute.value.query.filters).toContain('open');
+		});
+
+		it('keeps searchMode out of the route query', async () => {
+			const store = await setUpStore();
+
+			store.updateSearchMode('subject');
+			await new Promise((resolve) => setTimeout(resolve));
+
+			expect(router.currentRoute.value.query.searchMode).toBeUndefined();
+			expect(localStorage.getItem(`${namespace}/searchMode`)).toBe('subject');
+		});
+	});
+
+	describe('syncPersistence', () => {
+		it('publishes the applied filters', async () => {
+			const store = await setUpStore();
+			store.addFilter({
+				name: 'status',
+				value: 'open',
+			});
+			await new Promise((resolve) => setTimeout(resolve));
+			await router.push('/cases');
+
+			await runWithRouter(() => store.syncPersistence());
+
+			expect(router.currentRoute.value.query.filters).toContain('open');
+		});
+
+		it('publishes nothing while no filter is applied', async () => {
+			const store = await setUpStore();
+
+			await runWithRouter(() => store.syncPersistence());
+
+			expect(router.currentRoute.value.query).toEqual({});
+		});
+	});
+});

--- a/packages/ui-datalist/src/modules/filters/createTableFiltersStore.ts
+++ b/packages/ui-datalist/src/modules/filters/createTableFiltersStore.ts
@@ -1,4 +1,3 @@
-import { isEmpty } from '@webitel/ui-sdk/scripts';
 import { computed, reactive, ref } from 'vue';
 
 import { createDatalistStore } from '../_shared/createDatalistStore';
@@ -57,9 +56,6 @@ export const tableFiltersStoreBody = (
 			storages: [
 				PersistedStorageType.Route,
 			],
-
-			/* an empty FiltersManager serializes to "{}" – not worth publishing */
-			isEmptyValue: (value) => isEmpty(value) || value === '{}',
 
 			/* use custom .toString() logic, provided by FiltersManager */
 			onStore: async (save, { name }) => {

--- a/packages/ui-datalist/src/modules/filters/createTableFiltersStore.ts
+++ b/packages/ui-datalist/src/modules/filters/createTableFiltersStore.ts
@@ -44,10 +44,6 @@ export const tableFiltersStoreBody = (
 
 	const filtersList = computed(() => filtersManager.getFiltersList());
 
-	/*
-   kept to republish state into the route query on registry re-mount,
-    see syncPersistence()
-   */
 	let persistedStorageControllers: PersistedStorageController[] = [];
 
 	const setupPersistence = () => {
@@ -119,10 +115,7 @@ export const tableFiltersStoreBody = (
 		]);
 	};
 
-	/*
-   sequentially, because every route storage write is a router.replace()
-    built on top of the current route query
-   */
+	/* sequentially: every route write is a router.replace() on top of the current query */
 	const syncPersistence = async () => {
 		for (const controller of persistedStorageControllers) {
 			await controller.sync();

--- a/packages/ui-datalist/src/modules/filters/createTableFiltersStore.ts
+++ b/packages/ui-datalist/src/modules/filters/createTableFiltersStore.ts
@@ -1,3 +1,4 @@
+import { isEmpty } from '@webitel/ui-sdk/scripts';
 import { computed, reactive, ref } from 'vue';
 
 import { createDatalistStore } from '../_shared/createDatalistStore';
@@ -62,7 +63,7 @@ export const tableFiltersStoreBody = (
 			],
 
 			/* an empty FiltersManager serializes to "{}" – not worth publishing */
-			isEmptyValue: (value) => !value || value === '{}',
+			isEmptyValue: (value) => isEmpty(value) || value === '{}',
 
 			/* use custom .toString() logic, provided by FiltersManager */
 			onStore: async (save, { name }) => {

--- a/packages/ui-datalist/src/modules/filters/createTableFiltersStore.ts
+++ b/packages/ui-datalist/src/modules/filters/createTableFiltersStore.ts
@@ -1,7 +1,10 @@
 import { computed, reactive, ref } from 'vue';
 
 import { createDatalistStore } from '../_shared/createDatalistStore';
-import { PersistedStorageType } from '../persist/PersistedStorage.types';
+import {
+	type PersistedStorageController,
+	PersistedStorageType,
+} from '../persist/PersistedStorage.types';
 import { usePersistedStorage } from '../persist/usePersistedStorage';
 import type { Identifiable } from '../types/createDatalistStore.types';
 import type { useTableStoreConfig } from '../types/tableStore.types';
@@ -40,8 +43,14 @@ export const tableFiltersStoreBody = (
 
 	const filtersList = computed(() => filtersManager.getFiltersList());
 
+	/*
+   kept to republish state into the route query on registry re-mount,
+    see syncPersistence()
+   */
+	let persistedStorageControllers: PersistedStorageController[] = [];
+
 	const setupPersistence = () => {
-		const { restore: restoreFilters } = usePersistedStorage({
+		const filtersStorage = usePersistedStorage({
 			name: 'filters',
 
 			value: computed(
@@ -51,6 +60,9 @@ export const tableFiltersStoreBody = (
 			storages: [
 				PersistedStorageType.Route,
 			],
+
+			/* an empty FiltersManager serializes to "{}" – not worth publishing */
+			isEmptyValue: (value) => !value || value === '{}',
 
 			/* use custom .toString() logic, provided by FiltersManager */
 			onStore: async (save, { name }) => {
@@ -75,7 +87,7 @@ export const tableFiltersStoreBody = (
 			},
 		});
 
-		const { restore: restoreSearchMode } = usePersistedStorage({
+		const searchModeStorage = usePersistedStorage({
 			name: 'searchMode',
 			value: searchMode,
 			storages: [
@@ -95,10 +107,25 @@ export const tableFiltersStoreBody = (
 			},
 		});
 
+		persistedStorageControllers = [
+			filtersStorage,
+			searchModeStorage,
+		];
+
 		return Promise.all([
-			restoreFilters(),
-			restoreSearchMode(),
+			filtersStorage.restore(),
+			searchModeStorage.restore(),
 		]);
+	};
+
+	/*
+   sequentially, because every route storage write is a router.replace()
+    built on top of the current route query
+   */
+	const syncPersistence = async () => {
+		for (const controller of persistedStorageControllers) {
+			await controller.sync();
+		}
 	};
 
 	return {
@@ -116,6 +143,7 @@ export const tableFiltersStoreBody = (
 		updateSearchMode,
 
 		setupPersistence,
+		syncPersistence,
 	};
 };
 

--- a/packages/ui-datalist/src/modules/headers/__tests__/createTableHeadersStore.spec.ts
+++ b/packages/ui-datalist/src/modules/headers/__tests__/createTableHeadersStore.spec.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createApp } from 'vue';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+
+import type { DatalistTableHeader } from '../../types/tableStore.types';
+import { tableHeadersStoreBody } from '../createTableHeadersStore';
+
+const routes = [
+	{
+		path: '/cases',
+		name: 'cases',
+		component: {
+			template: '<div />',
+		},
+	},
+];
+
+const id = 'cases/headers';
+
+const rawHeaders = [
+	{
+		field: 'name',
+		show: true,
+		sort: null,
+	},
+	{
+		field: 'subject',
+		show: true,
+		sort: null,
+	},
+	{
+		field: 'createdAt',
+		show: false,
+		sort: null,
+	},
+] as DatalistTableHeader[];
+
+/* route writes are queued, so several ticks are needed for all of them to land */
+const flushWrites = async () => {
+	for (let i = 0; i < 5; i += 1) {
+		await new Promise((resolve) => setTimeout(resolve));
+	}
+};
+
+const createStore = () =>
+	tableHeadersStoreBody({
+		rawHeaders: rawHeaders.map((header) => ({
+			...header,
+		})),
+		id,
+	});
+
+describe('tableHeadersStoreBody', () => {
+	let router: Router;
+	let runWithRouter: <T>(fn: () => T) => T;
+
+	beforeEach(async () => {
+		localStorage.clear();
+
+		router = createRouter({
+			history: createMemoryHistory(),
+			routes,
+		});
+
+		const app = createApp({});
+		app.use(router);
+
+		await router.push('/cases');
+		await router.isReady();
+
+		runWithRouter = (fn) => app.runWithContext(fn);
+	});
+
+	const setUpStore = async () => {
+		const store = createStore();
+		await runWithRouter(() => store.setupPersistence());
+		return store;
+	};
+
+	it('exposes the shown headers and their fields', () => {
+		const store = createStore();
+
+		expect(store.shownHeaders.value.map(({ field }) => field)).toEqual([
+			'name',
+			'subject',
+		]);
+		expect(store.fields.value).toEqual([
+			'name',
+			'subject',
+		]);
+	});
+
+	it('has no sort by default', () => {
+		expect(createStore().sort.value).toBeNull();
+	});
+
+	it('encodes the sorted column into a sort query', () => {
+		const store = createStore();
+
+		store.updateSort(store.headers.value[0], 'desc');
+
+		expect(store.sort.value).toBe('-name');
+	});
+
+	it('collects the widths of resized columns', () => {
+		const store = createStore();
+
+		store.columnResize({
+			columnName: 'name',
+			columnWidth: '100px',
+		});
+
+		expect(store.columnWidths.value).toEqual({
+			name: '100px',
+		});
+	});
+
+	describe('persistence', () => {
+		it('restores shown fields from the route query', async () => {
+			await router.push({
+				name: 'cases',
+				query: {
+					fields: 'createdAt',
+				},
+			});
+
+			const store = await setUpStore();
+
+			expect(store.fields.value).toEqual([
+				'createdAt',
+			]);
+		});
+
+		it('writes a changed sort into the route query', async () => {
+			const store = await setUpStore();
+
+			store.updateSort(store.headers.value[0], 'asc');
+			await flushWrites();
+
+			expect(router.currentRoute.value.query.sort).toBe('+name');
+		});
+	});
+
+	describe('syncPersistence', () => {
+		it('publishes a customized column set', async () => {
+			const store = await setUpStore();
+			store.updateShownHeaders(
+				store.headers.value.map((header) => ({
+					...header,
+					show: header.field === 'name',
+				})),
+			);
+			await flushWrites();
+			await router.push('/cases');
+
+			await runWithRouter(() => store.syncPersistence());
+
+			expect(router.currentRoute.value.query.fields).toBe('name');
+		});
+
+		it('publishes nothing while the columns are still default', async () => {
+			const store = await setUpStore();
+
+			await runWithRouter(() => store.syncPersistence());
+
+			expect(router.currentRoute.value.query).toEqual({});
+		});
+	});
+});

--- a/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
+++ b/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
@@ -1,5 +1,5 @@
 import type { WtTableSortOrder } from '@webitel/ui-sdk/components/wt-table/types/WtTable';
-import { sortToQueryAdapter } from '@webitel/ui-sdk/scripts';
+import { isEmpty, sortToQueryAdapter } from '@webitel/ui-sdk/scripts';
 import { SortSymbols } from '@webitel/ui-sdk/scripts/sortQueryAdapters';
 import { computed, nextTick, ref } from 'vue';
 
@@ -269,7 +269,7 @@ export const tableHeadersStoreBody = ({
 			],
 			storagePath: id,
 			/* empty widths serialize to "{}" – not worth publishing */
-			isEmptyValue: (value) => !value || value === '{}',
+			isEmptyValue: (value) => isEmpty(value) || value === '{}',
 			onStore: (save, { name }) => {
 				const value = JSON.stringify(columnWidths.value);
 				return save({

--- a/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
+++ b/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
@@ -226,10 +226,6 @@ export const tableHeadersStoreBody = ({
 		});
 	};
 
-	/*
-   kept to republish state into the route query on registry re-mount,
-    see syncPersistence()
-   */
 	let persistedStorageControllers: PersistedStorageController[] = [];
 
 	const setupPersistence = async () => {
@@ -302,10 +298,7 @@ export const tableHeadersStoreBody = ({
 		]);
 	};
 
-	/*
-   sequentially, because every route storage write is a router.replace()
-    built on top of the current route query
-   */
+	/* sequentially: every route write is a router.replace() on top of the current query */
 	const syncPersistence = async () => {
 		for (const controller of persistedStorageControllers) {
 			await controller.sync();

--- a/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
+++ b/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
@@ -1,5 +1,5 @@
 import type { WtTableSortOrder } from '@webitel/ui-sdk/components/wt-table/types/WtTable';
-import { isEmpty, sortToQueryAdapter } from '@webitel/ui-sdk/scripts';
+import { sortToQueryAdapter } from '@webitel/ui-sdk/scripts';
 import { SortSymbols } from '@webitel/ui-sdk/scripts/sortQueryAdapters';
 import { computed, nextTick, ref } from 'vue';
 
@@ -264,8 +264,6 @@ export const tableHeadersStoreBody = ({
 				PersistedStorageType.LocalStorage,
 			],
 			storagePath: id,
-			/* empty widths serialize to "{}" – not worth publishing */
-			isEmptyValue: (value) => isEmpty(value) || value === '{}',
 			onStore: (save, { name }) => {
 				const value = JSON.stringify(columnWidths.value);
 				return save({

--- a/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
+++ b/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
@@ -4,7 +4,10 @@ import { SortSymbols } from '@webitel/ui-sdk/scripts/sortQueryAdapters';
 import { computed, nextTick, ref } from 'vue';
 
 import { createDatalistStore } from '../_shared/createDatalistStore';
-import { PersistedStorageType } from '../persist/PersistedStorage.types';
+import {
+	type PersistedStorageController,
+	PersistedStorageType,
+} from '../persist/PersistedStorage.types';
 import { usePersistedStorage } from '../persist/usePersistedStorage';
 import type { Identifiable } from '../types/createDatalistStore.types';
 import type {
@@ -223,8 +226,14 @@ export const tableHeadersStoreBody = ({
 		});
 	};
 
+	/*
+   kept to republish state into the route query on registry re-mount,
+    see syncPersistence()
+   */
+	let persistedStorageControllers: PersistedStorageController[] = [];
+
 	const setupPersistence = async () => {
-		const { restore: restoreFields } = usePersistedStorage({
+		const fieldsStorage = usePersistedStorage({
 			name: 'fields',
 			value: fields,
 			storages: [
@@ -247,18 +256,20 @@ export const tableHeadersStoreBody = ({
 			},
 		});
 
-		const { restore: restoreSort } = usePersistedStorage({
+		const sortStorage = usePersistedStorage({
 			name: 'sort',
 			value: sort,
 		});
 
-		const { restore: restoreColumnWidths } = usePersistedStorage({
+		const columnWidthsStorage = usePersistedStorage({
 			name: 'columnWidths',
 			value: columnWidths,
 			storages: [
 				PersistedStorageType.LocalStorage,
 			],
 			storagePath: id,
+			/* empty widths serialize to "{}" – not worth publishing */
+			isEmptyValue: (value) => !value || value === '{}',
 			onStore: (save, { name }) => {
 				const value = JSON.stringify(columnWidths.value);
 				return save({
@@ -278,11 +289,27 @@ export const tableHeadersStoreBody = ({
 			},
 		});
 
+		persistedStorageControllers = [
+			fieldsStorage,
+			sortStorage,
+			columnWidthsStorage,
+		];
+
 		return Promise.allSettled([
-			restoreFields(),
-			restoreSort(),
-			restoreColumnWidths(),
+			fieldsStorage.restore(),
+			sortStorage.restore(),
+			columnWidthsStorage.restore(),
 		]);
+	};
+
+	/*
+   sequentially, because every route storage write is a router.replace()
+    built on top of the current route query
+   */
+	const syncPersistence = async () => {
+		for (const controller of persistedStorageControllers) {
+			await controller.sync();
+		}
 	};
 
 	const getHeaderByField = (field: string) => {
@@ -334,6 +361,7 @@ export const tableHeadersStoreBody = ({
 		columnReorder,
 
 		setupPersistence,
+		syncPersistence,
 		$reset,
 	};
 };

--- a/packages/ui-datalist/src/modules/pagination/__tests__/createTablePaginationStore.spec.ts
+++ b/packages/ui-datalist/src/modules/pagination/__tests__/createTablePaginationStore.spec.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createApp } from 'vue';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+
+import { tablePaginationStoreBody } from '../createTablePaginationStore';
+
+const routes = [
+	{
+		path: '/cases',
+		name: 'cases',
+		component: {
+			template: '<div />',
+		},
+	},
+];
+
+describe('tablePaginationStoreBody', () => {
+	let router: Router;
+	let runWithRouter: <T>(fn: () => T) => T;
+
+	beforeEach(async () => {
+		router = createRouter({
+			history: createMemoryHistory(),
+			routes,
+		});
+
+		const app = createApp({});
+		app.use(router);
+
+		await router.push('/cases');
+		await router.isReady();
+
+		runWithRouter = (fn) => app.runWithContext(fn);
+	});
+
+	const setUpStore = async () => {
+		const store = tablePaginationStoreBody();
+		await runWithRouter(() => store.setupPersistence());
+		return store;
+	};
+
+	it('starts on the first page with the default size', () => {
+		const store = tablePaginationStoreBody();
+
+		expect(store.page.value).toBe(1);
+		expect(store.size.value).toBe(10);
+	});
+
+	it('updates page and size', () => {
+		const store = tablePaginationStoreBody();
+
+		store.updatePage(3);
+		store.updateSize(20);
+
+		expect(store.page.value).toBe(3);
+		expect(store.size.value).toBe(20);
+	});
+
+	it('resets to the defaults', () => {
+		const store = tablePaginationStoreBody();
+		store.updatePage(3);
+		store.updateSize(20);
+		store.next.value = true;
+
+		store.$reset();
+
+		expect(store.page.value).toBe(1);
+		expect(store.size.value).toBe(10);
+		expect(store.next.value).toBe(false);
+	});
+
+	describe('persistence', () => {
+		it('restores page and size from the route query', async () => {
+			await router.push({
+				name: 'cases',
+				query: {
+					page: '3',
+					size: '20',
+				},
+			});
+
+			const store = await setUpStore();
+
+			expect(store.page.value).toBe(3);
+			expect(store.size.value).toBe(20);
+		});
+
+		it('writes a changed page into the route query', async () => {
+			const store = await setUpStore();
+
+			store.updatePage(3);
+			await new Promise((resolve) => setTimeout(resolve));
+
+			expect(router.currentRoute.value.query.page).toBe('3');
+		});
+	});
+
+	describe('syncPersistence', () => {
+		it('publishes state the user changed', async () => {
+			const store = await setUpStore();
+			store.updatePage(3);
+			await router.push('/cases');
+
+			await runWithRouter(() => store.syncPersistence());
+
+			expect(router.currentRoute.value.query.page).toBe('3');
+		});
+
+		it('publishes nothing while the state is still default', async () => {
+			const store = await setUpStore();
+
+			await runWithRouter(() => store.syncPersistence());
+
+			expect(router.currentRoute.value.query).toEqual({});
+		});
+
+		it('does not overwrite a value already in the query', async () => {
+			const store = await setUpStore();
+			store.updatePage(3);
+			/* let the watcher settle, so its write cannot land after the push below */
+			await new Promise((resolve) => setTimeout(resolve));
+			await router.push({
+				name: 'cases',
+				query: {
+					page: '5',
+				},
+			});
+
+			await runWithRouter(() => store.syncPersistence());
+
+			expect(router.currentRoute.value.query.page).toBe('5');
+		});
+	});
+});

--- a/packages/ui-datalist/src/modules/pagination/createTablePaginationStore.ts
+++ b/packages/ui-datalist/src/modules/pagination/createTablePaginationStore.ts
@@ -25,10 +25,6 @@ export const tablePaginationStoreBody = () => {
 		next.value = false;
 	};
 
-	/*
-   kept to republish state into the route query on registry re-mount,
-    see syncPersistence()
-   */
 	let persistedStorageControllers: PersistedStorageController[] = [];
 
 	const setupPersistence = () => {
@@ -75,10 +71,7 @@ export const tablePaginationStoreBody = () => {
 		]);
 	};
 
-	/*
-   sequentially, because every route storage write is a router.replace()
-    built on top of the current route query
-   */
+	/* sequentially: every route write is a router.replace() on top of the current query */
 	const syncPersistence = async () => {
 		for (const controller of persistedStorageControllers) {
 			await controller.sync();

--- a/packages/ui-datalist/src/modules/pagination/createTablePaginationStore.ts
+++ b/packages/ui-datalist/src/modules/pagination/createTablePaginationStore.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue';
 
 import { createDatalistStore } from '../_shared/createDatalistStore';
+import type { PersistedStorageController } from '../persist/PersistedStorage.types';
 import { usePersistedStorage } from '../persist/usePersistedStorage';
 import type { Identifiable } from '../types/createDatalistStore.types';
 import type { useTableStoreConfig } from '../types/tableStore.types';
@@ -24,10 +25,22 @@ export const tablePaginationStoreBody = () => {
 		next.value = false;
 	};
 
+	/*
+   kept to republish state into the route query on registry re-mount,
+    see syncPersistence()
+   */
+	let persistedStorageControllers: PersistedStorageController[] = [];
+
 	const setupPersistence = () => {
-		const { restore: restorePage } = usePersistedStorage({
+		const pageStorage = usePersistedStorage({
 			name: 'page',
 			value: page,
+			onStore: (save, { name }) => {
+				return save({
+					name,
+					value: `${page.value}`,
+				});
+			},
 			onRestore: async (restore, name) => {
 				const value = await restore(name);
 				const numValue = Number(value);
@@ -35,9 +48,15 @@ export const tablePaginationStoreBody = () => {
 			},
 		});
 
-		const { restore: restoreSize } = usePersistedStorage({
+		const sizeStorage = usePersistedStorage({
 			name: 'size',
 			value: size,
+			onStore: (save, { name }) => {
+				return save({
+					name,
+					value: `${size.value}`,
+				});
+			},
 			onRestore: async (restore, name) => {
 				const value = await restore(name);
 				const numValue = Number(value);
@@ -45,10 +64,25 @@ export const tablePaginationStoreBody = () => {
 			},
 		});
 
+		persistedStorageControllers = [
+			pageStorage,
+			sizeStorage,
+		];
+
 		return Promise.allSettled([
-			restorePage(),
-			restoreSize(),
+			pageStorage.restore(),
+			sizeStorage.restore(),
 		]);
+	};
+
+	/*
+   sequentially, because every route storage write is a router.replace()
+    built on top of the current route query
+   */
+	const syncPersistence = async () => {
+		for (const controller of persistedStorageControllers) {
+			await controller.sync();
+		}
 	};
 
 	return {
@@ -60,6 +94,7 @@ export const tablePaginationStoreBody = () => {
 		updateSize,
 
 		setupPersistence,
+		syncPersistence,
 		$reset,
 	};
 };

--- a/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
+++ b/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
@@ -35,13 +35,6 @@ export interface PersistedPropertyConfig {
 	storagePath?: string;
 	startWatchManually?: boolean;
 	watchConfig?: WatchOptions;
-	/**
-	 * Used by `sync()` to decide whether the current value is worth publishing.
-	 * Receives the value already serialized for storing, so a store keeping its
-	 * state in a serialized object has to check for its own empty snapshot
-	 * (`"{}"`) on top of the default `isEmpty`.
-	 */
-	isEmptyValue?: (value: PersistStorableValue) => boolean;
 	onStore?: (
 		save: ({
 			name,
@@ -70,6 +63,10 @@ export interface PersistedStorageController {
 	 * Publishes the current value to every storage that holds nothing for `name`.
 	 * Storages that already hold a value are left untouched, so an explicit route
 	 * query always wins over in-memory state.
+	 *
+	 * A no-op for state still equal to the defaults: `restore()` captures the
+	 * snapshot a freshly created store serializes, and a controller that never
+	 * restored can only tell empty values apart.
 	 */
 	sync: () => Promise<void>;
 	reset: () => Promise<void>;

--- a/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
+++ b/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
@@ -37,7 +37,9 @@ export interface PersistedPropertyConfig {
 	watchConfig?: WatchOptions;
 	/**
 	 * Used by `sync()` to decide whether the current value is worth publishing.
-	 * Defaults to treating `null`/`undefined`/`''` as empty.
+	 * Receives the value already serialized for storing, so a store keeping its
+	 * state in a serialized object has to check for its own empty snapshot
+	 * (`"{}"`) on top of the default `isEmpty`.
 	 */
 	isEmptyValue?: (value: PersistStorableValue) => boolean;
 	onStore?: (

--- a/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
+++ b/packages/ui-datalist/src/modules/persist/PersistedStorage.types.ts
@@ -22,6 +22,10 @@ export interface StorageLike {
 	removeItem(key: string): Promise<void>;
 }
 
+export interface PersistedStorageAdapter extends StorageLike {
+	type: PersistedStorageType;
+}
+
 export interface PersistedPropertyConfig {
 	name: string;
 	// note: createTableHeadersStore passes a computed here, which the default
@@ -31,6 +35,11 @@ export interface PersistedPropertyConfig {
 	storagePath?: string;
 	startWatchManually?: boolean;
 	watchConfig?: WatchOptions;
+	/**
+	 * Used by `sync()` to decide whether the current value is worth publishing.
+	 * Defaults to treating `null`/`undefined`/`''` as empty.
+	 */
+	isEmptyValue?: (value: PersistStorableValue) => boolean;
 	onStore?: (
 		save: ({
 			name,
@@ -55,5 +64,11 @@ export interface PersistedStorageController {
 	watch: () => void;
 	unwatch: () => void;
 	restore: () => Promise<void>;
+	/**
+	 * Publishes the current value to every storage that holds nothing for `name`.
+	 * Storages that already hold a value are left untouched, so an explicit route
+	 * query always wins over in-memory state.
+	 */
+	sync: () => Promise<void>;
 	reset: () => Promise<void>;
 }

--- a/packages/ui-datalist/src/modules/persist/__tests__/useLocalStoragePersistedStorage.spec.ts
+++ b/packages/ui-datalist/src/modules/persist/__tests__/useLocalStoragePersistedStorage.spec.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useLocalStoragePersistedStorage } from '../useLocalStoragePersistedStorage';
+
+describe('useLocalStoragePersistedStorage', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it('namespaces keys with the storagePath', async () => {
+		const storage = useLocalStoragePersistedStorage({
+			storagePath: 'cases/headers',
+		});
+
+		await storage.setItem('fields', 'name,subject');
+
+		expect(localStorage.getItem('cases/headers/fields')).toBe('name,subject');
+	});
+
+	it('keeps stores with different paths apart', async () => {
+		const cases = useLocalStoragePersistedStorage({
+			storagePath: 'cases',
+		});
+		const contacts = useLocalStoragePersistedStorage({
+			storagePath: 'contacts',
+		});
+
+		await cases.setItem('fields', 'subject');
+		await contacts.setItem('fields', 'name');
+
+		expect(await cases.getItem('fields')).toBe('subject');
+		expect(await contacts.getItem('fields')).toBe('name');
+	});
+
+	it('resolves null for a missing key', async () => {
+		const storage = useLocalStoragePersistedStorage({
+			storagePath: 'cases',
+		});
+
+		expect(await storage.getItem('fields')).toBeNull();
+	});
+
+	it('stores an array as a comma-joined value', async () => {
+		const storage = useLocalStoragePersistedStorage({
+			storagePath: 'cases',
+		});
+
+		await storage.setItem('fields', [
+			'name',
+			'subject',
+		]);
+
+		expect(await storage.getItem('fields')).toBe('name,subject');
+	});
+
+	it('removes a key', async () => {
+		const storage = useLocalStoragePersistedStorage({
+			storagePath: 'cases',
+		});
+		await storage.setItem('fields', 'name');
+
+		await storage.removeItem('fields');
+
+		expect(await storage.getItem('fields')).toBeNull();
+	});
+});

--- a/packages/ui-datalist/src/modules/persist/__tests__/usePersistedStorage.spec.ts
+++ b/packages/ui-datalist/src/modules/persist/__tests__/usePersistedStorage.spec.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ref } from 'vue';
+import { type Ref, ref } from 'vue';
 
 import {
+	type PersistableValue,
 	PersistedStorageType,
 	type StorageLike,
 } from '../PersistedStorage.types';
@@ -108,13 +109,67 @@ describe('usePersistedStorage', () => {
 			expect(routeStorage.value).toBeNull();
 		});
 
-		it('skips values considered empty by isEmptyValue', async () => {
-			const value = ref('{}');
+		it('skips a value still equal to the default captured by restore', async () => {
+			const value = ref('default-page');
+
+			const storage = usePersistedStorage({
+				name: 'page',
+				value,
+			});
+			await storage.restore();
+			await storage.sync();
+
+			expect(routeStorage.setItem).not.toHaveBeenCalled();
+			expect(routeStorage.value).toBeNull();
+		});
+
+		it('publishes a value changed after restore', async () => {
+			const value = ref('default-page');
+
+			const storage = usePersistedStorage({
+				name: 'page',
+				value,
+			});
+			await storage.restore();
+			storage.unwatch();
+			value.value = '3';
+			await storage.sync();
+
+			expect(routeStorage.value).toBe('3');
+		});
+
+		it('captures the default through onStore serialization', async () => {
+			const filters = ref<Record<string, string>>({});
+
+			const storage = usePersistedStorage({
+				name: 'filters',
+				value: filters as unknown as Ref<PersistableValue>,
+				onStore: (save, { name }) =>
+					save({
+						name,
+						value: JSON.stringify(filters.value),
+					}),
+			});
+			await storage.restore();
+			storage.unwatch();
+
+			/* an empty snapshot serializes to "{}" – the default, nothing to publish */
+			await storage.sync();
+			expect(routeStorage.setItem).not.toHaveBeenCalled();
+
+			filters.value = {
+				name: 'test',
+			};
+			await storage.sync();
+			expect(routeStorage.value).toBe('{"name":"test"}');
+		});
+
+		it('skips empty values when restore never ran', async () => {
+			const value = ref('');
 
 			await usePersistedStorage({
 				name: 'filters',
 				value,
-				isEmptyValue: (storedValue) => !storedValue || storedValue === '{}',
 			}).sync();
 
 			expect(routeStorage.setItem).not.toHaveBeenCalled();

--- a/packages/ui-datalist/src/modules/persist/__tests__/usePersistedStorage.spec.ts
+++ b/packages/ui-datalist/src/modules/persist/__tests__/usePersistedStorage.spec.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+
+import {
+	PersistedStorageType,
+	type StorageLike,
+} from '../PersistedStorage.types';
+
+const createStorageMock = (): StorageLike & {
+	value: string | null;
+} => {
+	const storage = {
+		value: null as string | null,
+		getItem: vi.fn(async () => storage.value),
+		setItem: vi.fn(async (_key: string, value: string) => {
+			storage.value = value;
+		}),
+		removeItem: vi.fn(async () => {
+			storage.value = null;
+		}),
+	};
+
+	return storage;
+};
+
+const routeStorage = createStorageMock();
+const localStorage = createStorageMock();
+
+/*
+ route storage resolves `undefined` for a missing query param,
+  local storage resolves `null` – both are mocked to keep that difference
+ */
+vi.mock('../useRoutePersistedStorage', () => ({
+	useRoutePersistedStorage: () => ({
+		getItem: (key: string) =>
+			routeStorage.getItem(key).then((value) => value ?? undefined),
+		setItem: routeStorage.setItem,
+		removeItem: routeStorage.removeItem,
+	}),
+}));
+
+vi.mock('../useLocalStoragePersistedStorage', () => ({
+	useLocalStoragePersistedStorage: () => localStorage,
+}));
+
+const { usePersistedStorage } = await import('../usePersistedStorage');
+
+describe('usePersistedStorage', () => {
+	beforeEach(() => {
+		routeStorage.value = null;
+		localStorage.value = null;
+		vi.clearAllMocks();
+	});
+
+	describe('sync', () => {
+		it('publishes the current value to an empty storage', async () => {
+			const value = ref('filtered');
+
+			await usePersistedStorage({
+				name: 'filters',
+				value,
+			}).sync();
+
+			expect(routeStorage.setItem).toHaveBeenCalledWith('filters', 'filtered');
+			expect(routeStorage.value).toBe('filtered');
+		});
+
+		it('does not overwrite a storage that already holds a value', async () => {
+			routeStorage.value = 'from-url';
+			const value = ref('from-memory');
+
+			await usePersistedStorage({
+				name: 'filters',
+				value,
+			}).sync();
+
+			expect(routeStorage.setItem).not.toHaveBeenCalled();
+			expect(routeStorage.value).toBe('from-url');
+		});
+
+		it('publishes only to the storages that hold nothing', async () => {
+			localStorage.value = 'from-local-storage';
+			const value = ref('from-memory');
+
+			await usePersistedStorage({
+				name: 'fields',
+				value,
+				storages: [
+					PersistedStorageType.Route,
+					PersistedStorageType.LocalStorage,
+				],
+			}).sync();
+
+			expect(routeStorage.value).toBe('from-memory');
+			expect(localStorage.setItem).not.toHaveBeenCalled();
+			expect(localStorage.value).toBe('from-local-storage');
+		});
+
+		it('skips empty values', async () => {
+			const value = ref('');
+
+			await usePersistedStorage({
+				name: 'filters',
+				value,
+			}).sync();
+
+			expect(routeStorage.setItem).not.toHaveBeenCalled();
+			expect(routeStorage.value).toBeNull();
+		});
+
+		it('skips values considered empty by isEmptyValue', async () => {
+			const value = ref('{}');
+
+			await usePersistedStorage({
+				name: 'filters',
+				value,
+				isEmptyValue: (storedValue) => !storedValue || storedValue === '{}',
+			}).sync();
+
+			expect(routeStorage.setItem).not.toHaveBeenCalled();
+		});
+
+		it('stores value serialized by onStore', async () => {
+			const value = ref('ignored-raw-value');
+
+			await usePersistedStorage({
+				name: 'filters',
+				value,
+				onStore: (save, { name }) =>
+					save({
+						name,
+						value: 'serialized',
+					}),
+			}).sync();
+
+			expect(routeStorage.value).toBe('serialized');
+		});
+
+		it('does not start watching the value', async () => {
+			const value = ref('filtered');
+
+			await usePersistedStorage({
+				name: 'filters',
+				value,
+			}).sync();
+
+			vi.clearAllMocks();
+			value.value = 'changed';
+			await new Promise((resolve) => setTimeout(resolve));
+
+			expect(routeStorage.setItem).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('restore', () => {
+		it('falls back to the next storage when the route holds nothing', async () => {
+			localStorage.value = 'from-local-storage';
+			const value = ref('');
+
+			await usePersistedStorage({
+				name: 'fields',
+				value,
+				storages: [
+					PersistedStorageType.Route,
+					PersistedStorageType.LocalStorage,
+				],
+			}).restore();
+
+			expect(value.value).toBe('from-local-storage');
+		});
+
+		it('prefers the route value over the next storages', async () => {
+			routeStorage.value = 'from-url';
+			localStorage.value = 'from-local-storage';
+			const value = ref('');
+
+			await usePersistedStorage({
+				name: 'fields',
+				value,
+				storages: [
+					PersistedStorageType.Route,
+					PersistedStorageType.LocalStorage,
+				],
+			}).restore();
+
+			expect(value.value).toBe('from-url');
+		});
+	});
+});

--- a/packages/ui-datalist/src/modules/persist/__tests__/usePersistedStorage.spec.ts
+++ b/packages/ui-datalist/src/modules/persist/__tests__/usePersistedStorage.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type Ref, ref } from 'vue';
+import { nextTick, type Ref, ref } from 'vue';
 
 import {
 	type PersistableValue,
@@ -239,6 +239,119 @@ describe('usePersistedStorage', () => {
 			}).restore();
 
 			expect(value.value).toBe('from-url');
+		});
+
+		it('leaves the value untouched when no storage holds anything', async () => {
+			const value = ref('in-memory');
+
+			await usePersistedStorage({
+				name: 'fields',
+				value,
+			}).restore();
+
+			expect(value.value).toBe('in-memory');
+		});
+
+		it('hands the first non-null value to onRestore', async () => {
+			localStorage.value = 'from-local-storage';
+			const onRestore = vi.fn();
+
+			await usePersistedStorage({
+				name: 'fields',
+				value: ref(''),
+				storages: [
+					PersistedStorageType.Route,
+					PersistedStorageType.LocalStorage,
+				],
+				onRestore: async (restore, name) => {
+					onRestore(await restore(name));
+				},
+			}).restore();
+
+			expect(onRestore).toHaveBeenCalledWith('from-local-storage');
+		});
+	});
+
+	describe('watch', () => {
+		it('writes a changed value to every storage', async () => {
+			const value = ref('initial');
+
+			await usePersistedStorage({
+				name: 'fields',
+				value,
+				storages: [
+					PersistedStorageType.Route,
+					PersistedStorageType.LocalStorage,
+				],
+			}).restore();
+
+			value.value = 'changed';
+			await nextTick();
+
+			expect(routeStorage.value).toBe('changed');
+			expect(localStorage.value).toBe('changed');
+		});
+
+		it('does not write the value restored from a storage back', async () => {
+			routeStorage.value = 'from-url';
+
+			await usePersistedStorage({
+				name: 'filters',
+				value: ref(''),
+			}).restore();
+			await nextTick();
+
+			expect(routeStorage.setItem).not.toHaveBeenCalled();
+		});
+
+		it('does not start watching when startWatchManually is set', async () => {
+			const value = ref('initial');
+
+			await usePersistedStorage({
+				name: 'filters',
+				value,
+				startWatchManually: true,
+			}).restore();
+
+			value.value = 'changed';
+			await nextTick();
+
+			expect(routeStorage.setItem).not.toHaveBeenCalled();
+		});
+
+		it('stops writing after unwatch', async () => {
+			const value = ref('initial');
+
+			const storage = usePersistedStorage({
+				name: 'filters',
+				value,
+			});
+			await storage.restore();
+			storage.unwatch();
+
+			value.value = 'changed';
+			await nextTick();
+
+			expect(routeStorage.setItem).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('reset', () => {
+		it('removes the value from every storage', async () => {
+			routeStorage.value = 'from-url';
+			localStorage.value = 'from-local-storage';
+
+			await usePersistedStorage({
+				name: 'fields',
+				value: ref('in-memory'),
+				storages: [
+					PersistedStorageType.Route,
+					PersistedStorageType.LocalStorage,
+				],
+			}).reset();
+
+			expect(routeStorage.value).toBeNull();
+			expect(localStorage.value).toBeNull();
 		});
 	});
 });

--- a/packages/ui-datalist/src/modules/persist/__tests__/useRoutePersistedStorage.spec.ts
+++ b/packages/ui-datalist/src/modules/persist/__tests__/useRoutePersistedStorage.spec.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createApp } from 'vue';
+import {
+	createMemoryHistory,
+	createRouter,
+	type Router,
+	useRoute,
+} from 'vue-router';
+
+import type { StorageLike } from '../PersistedStorage.types';
+import { useRoutePersistedStorage } from '../useRoutePersistedStorage';
+
+const routes = [
+	{
+		path: '/',
+		name: 'root',
+		component: {
+			template: '<div />',
+		},
+	},
+	{
+		path: '/cases/:id?',
+		name: 'cases',
+		component: {
+			template: '<div />',
+		},
+	},
+];
+
+describe('useRoutePersistedStorage', () => {
+	let router: Router;
+	let storage: StorageLike;
+	let currentQuery: () => Record<string, unknown>;
+
+	beforeEach(async () => {
+		router = createRouter({
+			history: createMemoryHistory(),
+			routes,
+		});
+
+		const app = createApp({});
+		app.use(router);
+
+		await router.push('/');
+		await router.isReady();
+
+		app.runWithContext(() => {
+			storage = useRoutePersistedStorage();
+			const route = useRoute();
+			currentQuery = () => route.query;
+		});
+	});
+
+	it('reads a value from the route query', async () => {
+		await router.push({
+			name: 'cases',
+			query: {
+				page: '3',
+			},
+		});
+
+		expect(await storage.getItem('page')).toBe('3');
+	});
+
+	it('resolves undefined for a missing query param', async () => {
+		expect(await storage.getItem('page')).toBeUndefined();
+	});
+
+	it('writes a value keeping the rest of the query', async () => {
+		await router.push({
+			name: 'cases',
+			query: {
+				filters: '{"name":"test"}',
+			},
+		});
+
+		await storage.setItem('page', '3');
+
+		expect(currentQuery()).toEqual({
+			filters: '{"name":"test"}',
+			page: '3',
+		});
+	});
+
+	it('writes without leaving the current route', async () => {
+		await router.push({
+			name: 'cases',
+			params: {
+				id: '42',
+			},
+			hash: '#tab',
+		});
+
+		await storage.setItem('page', '3');
+
+		expect(router.currentRoute.value.name).toBe('cases');
+		expect(router.currentRoute.value.params.id).toBe('42');
+		expect(router.currentRoute.value.hash).toBe('#tab');
+	});
+
+	it('does not add a history entry', async () => {
+		await router.push({
+			name: 'cases',
+		});
+		const positionBefore = window.history.length;
+
+		await storage.setItem('page', '3');
+
+		expect(window.history.length).toBe(positionBefore);
+	});
+
+	it('keeps every key when writes are issued concurrently', async () => {
+		await router.push({
+			name: 'cases',
+		});
+
+		await Promise.all([
+			storage.setItem('page', '3'),
+			storage.setItem('sort', '-createdAt'),
+			storage.setItem('fields', 'name,subject'),
+		]);
+
+		expect(currentQuery()).toEqual({
+			page: '3',
+			sort: '-createdAt',
+			fields: 'name,subject',
+		});
+	});
+
+	it('removes a value keeping the rest of the query', async () => {
+		await router.push({
+			name: 'cases',
+			query: {
+				page: '3',
+				size: '20',
+			},
+		});
+
+		await storage.removeItem('page');
+
+		expect(currentQuery()).toEqual({
+			size: '20',
+		});
+	});
+});

--- a/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
+++ b/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
@@ -3,12 +3,21 @@ import { type WatchHandle, watch } from 'vue';
 import {
 	type PersistableValue,
 	type PersistedPropertyConfig,
+	type PersistedStorageAdapter,
 	type PersistedStorageController,
 	PersistedStorageType,
-	type StorageLike,
+	type PersistStorableValue,
 } from './PersistedStorage.types';
 import { useLocalStoragePersistedStorage } from './useLocalStoragePersistedStorage';
 import { useRoutePersistedStorage } from './useRoutePersistedStorage';
+
+const toStorableValue = (value: PersistableValue): PersistStorableValue => {
+	return typeof value === 'string' ? value : (value?.toString() ?? '');
+};
+
+const isEmptyValueByDefault = (value: PersistStorableValue) => {
+	return value == null || value === '';
+};
 
 export const usePersistedStorage = ({
 	name,
@@ -18,14 +27,13 @@ export const usePersistedStorage = ({
 	],
 	storagePath,
 	startWatchManually = false,
+	isEmptyValue = isEmptyValueByDefault,
 	onStore,
 	onRestore,
 }: PersistedPropertyConfig): PersistedStorageController => {
 	let unwatch: WatchHandle | null = null;
 
-	const setItemFns: StorageLike['setItem'][] = [];
-	const getItemFns: StorageLike['getItem'][] = [];
-	const removeItemFns: StorageLike['removeItem'][] = [];
+	const adapters: PersistedStorageAdapter[] = [];
 
 	// `null` entries are kept: callers below pick the first non-null value, so the
 	// per-storage misses have to stay in the list to preserve priority order.
@@ -33,7 +41,7 @@ export const usePersistedStorage = ({
 		name: string,
 	): Promise<Array<PersistableValue | null>> => {
 		const settledResults = await Promise.allSettled(
-			getItemFns.map((getter) => getter(name)),
+			adapters.map(({ getItem }) => getItem(name)),
 		);
 
 		return settledResults.reduce(
@@ -57,58 +65,79 @@ export const usePersistedStorage = ({
   order matters, as the first storage in the list has the highest priority
    */
 	if (storages.includes(PersistedStorageType.Route)) {
-		const { setItem, getItem, removeItem } = useRoutePersistedStorage();
-		setItemFns.push(setItem);
-		getItemFns.push(getItem);
-		removeItemFns.push(removeItem);
+		adapters.push({
+			type: PersistedStorageType.Route,
+			...useRoutePersistedStorage(),
+		});
 	}
 
 	if (storages.includes(PersistedStorageType.LocalStorage)) {
-		const { setItem, getItem, removeItem } = useLocalStoragePersistedStorage({
-			storagePath,
+		adapters.push({
+			type: PersistedStorageType.LocalStorage,
+			...useLocalStoragePersistedStorage({
+				storagePath,
+			}),
 		});
-		setItemFns.push(setItem);
-		getItemFns.push(getItem);
-		removeItemFns.push(removeItem);
 	}
+
+	/*
+   single storing path, shared by the watcher and by sync():
+    the watcher writes to every storage, sync() writes only to the empty ones
+   */
+	const store = async ({
+		targets,
+		skipEmpty = false,
+	}: {
+		targets: PersistedStorageAdapter[];
+		skipEmpty?: boolean;
+	}) => {
+		if (!targets.length) return;
+
+		const save = async ({
+			name,
+			value: storedValue,
+		}: {
+			name: string;
+			value: PersistableValue;
+		}) => {
+			if (skipEmpty && isEmptyValue(toStorableValue(storedValue))) return;
+
+			await Promise.all(
+				targets.map((adapter) => adapter.setItem(name, storedValue)),
+			);
+		};
+
+		/*
+     if onStore callback is provided,
+      call custom logic for storing value
+     */
+		if (onStore) {
+			/*
+       save is wrapped in one callback,
+        so that onStore is called only once on each value change
+       */
+			await onStore(save, {
+				name,
+				value: value.value ?? '',
+			});
+		} else {
+			/*
+       else, perform default storing logic
+       */
+			await save({
+				name,
+				value: value.value ?? '',
+			});
+		}
+	};
 
 	const startWatch = () => {
 		unwatch = watch(
 			value,
-			async () => {
-				/*
-       if onStore callback is provided,
-        call custom logic for storing value
-       */
-				if (onStore) {
-					/*
-         wrap all setItemFns in one callback
-          so that onStore is called only once on each value change
-         */
-					const save = async ({
-						name,
-						value: storedValue,
-					}: {
-						name: string;
-						value: PersistableValue;
-					}) => {
-						setItemFns.forEach((setter) => {
-							setter(name, storedValue);
-						});
-					};
-					await onStore(save, {
-						name,
-						value: value.value ?? '',
-					});
-				} else {
-					/*
-       else, perform default storing logic
-       */
-					const storedValue = value.value ?? '';
-					setItemFns.forEach((setter) => {
-						setter(name, storedValue);
-					});
-				}
+			() => {
+				store({
+					targets: adapters,
+				});
 			},
 			{
 				deep: true,
@@ -142,9 +171,14 @@ export const usePersistedStorage = ({
        else, perform default restoring logic
        */
 			const restoredValues = await composedValueGetter(name);
-			const restoredValue = restoredValues.find((value) => value !== null);
+			/*
+       loose check on purpose: useRoutePersistedStorage resolves `undefined`
+        for a missing query param, so a storage listed after the route one
+        would never win with a strict `!== null`
+       */
+			const restoredValue = restoredValues.find((value) => value != null);
 
-			if (restoredValue !== undefined) {
+			if (restoredValue != null) {
 				value.value = restoredValue;
 			}
 		}
@@ -157,8 +191,24 @@ export const usePersistedStorage = ({
 		}
 	};
 
+	const sync = async () => {
+		const settledResults = await Promise.allSettled(
+			adapters.map(({ getItem }) => getItem(name)),
+		);
+
+		const emptyStorages = adapters.filter((_, index) => {
+			const result = settledResults[index];
+			return result.status === 'fulfilled' && result.value == null;
+		});
+
+		return store({
+			targets: emptyStorages,
+			skipEmpty: true,
+		});
+	};
+
 	const reset = async () => {
-		await Promise.all(removeItemFns.map((removeItem) => removeItem(name)));
+		await Promise.all(adapters.map(({ removeItem }) => removeItem(name)));
 	};
 
 	const endWatch = () => unwatch?.();
@@ -167,6 +217,7 @@ export const usePersistedStorage = ({
 		watch: startWatch,
 		unwatch: endWatch,
 		restore,
+		sync,
 		reset,
 	};
 };

--- a/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
+++ b/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
@@ -24,11 +24,11 @@ export const usePersistedStorage = ({
 	],
 	storagePath,
 	startWatchManually = false,
-	isEmptyValue = isEmpty,
 	onStore,
 	onRestore,
 }: PersistedPropertyConfig): PersistedStorageController => {
 	let unwatch: WatchHandle | null = null;
+	let defaultSnapshot: PersistStorableValue | undefined;
 
 	const adapters: PersistedStorageAdapter[] = [];
 
@@ -77,51 +77,52 @@ export const usePersistedStorage = ({
 		});
 	}
 
-	/* the watcher writes to every storage, sync() only to the empty ones */
-	const store = async ({
-		targets,
-		skipEmpty = false,
-	}: {
-		targets: PersistedStorageAdapter[];
-		skipEmpty?: boolean;
-	}) => {
-		if (!targets.length) return;
-
-		const save = async ({
-			name,
-			value: storedValue,
-		}: {
-			name: string;
-			value: PersistableValue;
-		}) => {
-			if (skipEmpty && isEmptyValue(toStorableValue(storedValue))) return;
-
-			await Promise.all(
-				targets.map((adapter) => adapter.setItem(name, storedValue)),
-			);
-		};
-
+	/*
+   runs the storing path with a `save` doing whatever the caller needs:
+    writing to the storages, or merely capturing the serialized value
+   */
+	const runStoringPath = async (
+		save: (params: { name: string; value: PersistableValue }) => Promise<void>,
+	) => {
 		if (onStore) {
 			/* save is wrapped in one callback, so that onStore is called only once */
-			await onStore(save, {
-				name,
-				value: value.value ?? '',
-			});
-		} else {
-			await save({
+			return onStore(save, {
 				name,
 				value: value.value ?? '',
 			});
 		}
+
+		return save({
+			name,
+			value: value.value ?? '',
+		});
+	};
+
+	const serialize = async () => {
+		let serializedValue: PersistStorableValue = '';
+
+		await runStoringPath(async ({ value: storedValue }) => {
+			serializedValue = toStorableValue(storedValue);
+		});
+
+		return serializedValue;
+	};
+
+	const store = (targets: PersistedStorageAdapter[]) => {
+		if (!targets.length) return Promise.resolve();
+
+		return runStoringPath(async ({ name, value: storedValue }) => {
+			await Promise.all(
+				targets.map((adapter) => adapter.setItem(name, storedValue)),
+			);
+		});
 	};
 
 	const startWatch = () => {
 		unwatch = watch(
 			value,
 			() => {
-				store({
-					targets: adapters,
-				});
+				store(adapters);
 			},
 			{
 				deep: true,
@@ -130,6 +131,12 @@ export const usePersistedStorage = ({
 	};
 
 	const restore = async () => {
+		/*
+     nothing has mutated the value yet, so this is what a freshly created store
+      serializes – sync() uses it to tell untouched state from a real one
+     */
+		defaultSnapshot = await serialize();
+
 		if (onRestore) {
 			/* every getter is wrapped in one callback, so that onRestore is called only once */
 			const restore = async (name: string) => {
@@ -166,6 +173,10 @@ export const usePersistedStorage = ({
 	};
 
 	const sync = async () => {
+		const serializedValue = await serialize();
+
+		if (isEmpty(serializedValue) || serializedValue === defaultSnapshot) return;
+
 		const settledResults = await Promise.allSettled(
 			adapters.map(({ getItem }) => getItem(name)),
 		);
@@ -175,10 +186,7 @@ export const usePersistedStorage = ({
 			return result.status === 'fulfilled' && result.value == null;
 		});
 
-		return store({
-			targets: emptyStorages,
-			skipEmpty: true,
-		});
+		return store(emptyStorages);
 	};
 
 	const reset = async () => {

--- a/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
+++ b/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
@@ -77,10 +77,7 @@ export const usePersistedStorage = ({
 		});
 	}
 
-	/*
-   single storing path, shared by the watcher and by sync():
-    the watcher writes to every storage, sync() writes only to the empty ones
-   */
+	/* the watcher writes to every storage, sync() only to the empty ones */
 	const store = async ({
 		targets,
 		skipEmpty = false,
@@ -104,23 +101,13 @@ export const usePersistedStorage = ({
 			);
 		};
 
-		/*
-     if onStore callback is provided,
-      call custom logic for storing value
-     */
 		if (onStore) {
-			/*
-       save is wrapped in one callback,
-        so that onStore is called only once on each value change
-       */
+			/* save is wrapped in one callback, so that onStore is called only once */
 			await onStore(save, {
 				name,
 				value: value.value ?? '',
 			});
 		} else {
-			/*
-       else, perform default storing logic
-       */
 			await save({
 				name,
 				value: value.value ?? '',
@@ -143,15 +130,8 @@ export const usePersistedStorage = ({
 	};
 
 	const restore = async () => {
-		/*
-       if onRestore callback is provided,
-        call custom logic for restoring value
-       */
 		if (onRestore) {
-			/*
-         wrap all getItemFns in one callback
-          so that onRestore is called only once on each value change
-         */
+			/* every getter is wrapped in one callback, so that onRestore is called only once */
 			const restore = async (name: string) => {
 				const restoredValues = await composedValueGetter(name);
 				/*
@@ -164,9 +144,6 @@ export const usePersistedStorage = ({
 			};
 			await onRestore(restore, name);
 		} else {
-			/*
-       else, perform default restoring logic
-       */
 			const restoredValues = await composedValueGetter(name);
 			/*
        loose check on purpose: useRoutePersistedStorage resolves `undefined`

--- a/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
+++ b/packages/ui-datalist/src/modules/persist/usePersistedStorage.ts
@@ -1,3 +1,4 @@
+import { isEmpty } from '@webitel/ui-sdk/scripts';
 import { type WatchHandle, watch } from 'vue';
 
 import {
@@ -15,10 +16,6 @@ const toStorableValue = (value: PersistableValue): PersistStorableValue => {
 	return typeof value === 'string' ? value : (value?.toString() ?? '');
 };
 
-const isEmptyValueByDefault = (value: PersistStorableValue) => {
-	return value == null || value === '';
-};
-
 export const usePersistedStorage = ({
 	name,
 	value,
@@ -27,7 +24,7 @@ export const usePersistedStorage = ({
 	],
 	storagePath,
 	startWatchManually = false,
-	isEmptyValue = isEmptyValueByDefault,
+	isEmptyValue = isEmpty,
 	onStore,
 	onRestore,
 }: PersistedPropertyConfig): PersistedStorageController => {

--- a/packages/ui-datalist/src/modules/persist/useRoutePersistedStorage.ts
+++ b/packages/ui-datalist/src/modules/persist/useRoutePersistedStorage.ts
@@ -2,6 +2,23 @@ import { useRoute, useRouter } from 'vue-router';
 
 import type { StorageLike } from './PersistedStorage.types.ts';
 
+/*
+ every write is a router.replace() built on top of the current query, and the
+  query only changes once the navigation resolves – so concurrent writes would
+  all start from the same snapshot and drop each other's keys. they are queued
+  process-wide: a table store writes several properties at once (a new sort
+  makes both `sort` and `fields` emit), and all of them target the same router
+ */
+let pendingWrite: Promise<unknown> = Promise.resolve();
+
+const enqueueWrite = <T>(write: () => Promise<T>): Promise<T> => {
+	const result = pendingWrite.then(write, write);
+
+	pendingWrite = result.catch(() => {});
+
+	return result;
+};
+
 export const useRoutePersistedStorage = (): StorageLike => {
 	const router = useRouter();
 	const route = useRoute();
@@ -11,27 +28,32 @@ export const useRoutePersistedStorage = (): StorageLike => {
 	};
 
 	const setItem = async (key: string, value: string | string[]) => {
-		await router.replace({
-			name: route.name,
-			params: route.params,
-			hash: route.hash,
-			query: {
-				...route.query,
-				[key]: value,
-			},
-		});
+		await enqueueWrite(() =>
+			router.replace({
+				name: route.name,
+				params: route.params,
+				hash: route.hash,
+				query: {
+					...route.query,
+					[key]: value,
+				},
+			}),
+		);
 	};
 
 	const removeItem = async (key: string) => {
-		const query = {
-			...route.query,
-		};
-		delete query[key];
-		await router.replace({
-			name: route.name,
-			params: route.params,
-			hash: route.hash,
-			query,
+		await enqueueWrite(() => {
+			const query = {
+				...route.query,
+			};
+			delete query[key];
+
+			return router.replace({
+				name: route.name,
+				params: route.params,
+				hash: route.hash,
+				query,
+			});
 		});
 	};
 

--- a/packages/ui-datalist/src/modules/table/createTableStore.store.ts
+++ b/packages/ui-datalist/src/modules/table/createTableStore.store.ts
@@ -320,8 +320,15 @@ export const tableStoreBody = <Entity extends Identifiable>(
 
 		await setupStore();
 
-		/* on the first setup the restore path is authoritative */
-		if (isStoreAlreadySetUp && !disablePersistence) {
+		/*
+     on the first setup the restore path is authoritative.
+
+     a store initialized with a parentId is a list nested in a card page, not a
+      registry: it shares the query param names with the registry stores, and
+      the url it would publish into is the card one – so it keeps writing on
+      change only, and syncs merely on demand
+     */
+		if (isStoreAlreadySetUp && !disablePersistence && !storeParentId) {
 			await syncPersistence();
 		}
 

--- a/packages/ui-datalist/src/modules/table/createTableStore.store.ts
+++ b/packages/ui-datalist/src/modules/table/createTableStore.store.ts
@@ -299,11 +299,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 	 * it, or reaching it from the menu) used to render filtered data behind a
 	 * bare url, losing filters on reload or on copying the link.
 	 *
-	 * Storages that already hold a value are left untouched, so an explicit query
-	 * always wins over in-memory state.
-	 *
-	 * Sequentially, because every route storage write is a router.replace()
-	 * built on top of the current route query.
+	 * [WTEL-10093](https://webitel.atlassian.net/browse/WTEL-10093)
 	 */
 	const syncPersistence = async () => {
 		await syncPaginationPersistence();
@@ -324,10 +320,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 
 		await setupStore();
 
-		/*
-     on the first setup the restore path is authoritative,
-      so publishing is needed on re-mounts only
-     */
+		/* on the first setup the restore path is authoritative */
 		if (isStoreAlreadySetUp && !disablePersistence) {
 			await syncPersistence();
 		}

--- a/packages/ui-datalist/src/modules/table/createTableStore.store.ts
+++ b/packages/ui-datalist/src/modules/table/createTableStore.store.ts
@@ -46,6 +46,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 		// $reset: $resetPaginationStore,
 		$patch: $patchPaginationStore,
 		setupPersistence: setupPaginationPersistence,
+		syncPersistence: syncPaginationPersistence,
 	} = paginationStore;
 
 	const headersStore = useHeadersStore();
@@ -63,6 +64,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 		columnReorder,
 		updateShownHeaders,
 		setupPersistence: setupHeadersPersistence,
+		syncPersistence: syncHeadersPersistence,
 	} = headersStore;
 
 	const filtersStore = useFiltersStore();
@@ -77,6 +79,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 		updateFilter,
 		deleteFilter,
 		setupPersistence: setupFiltersPersistence,
+		syncPersistence: syncFiltersPersistence,
 		updateSearchMode,
 	} = filtersStore;
 
@@ -285,6 +288,29 @@ export const tableStoreBody = <Entity extends Identifiable>(
 		isStoreSetUp.value = true;
 	};
 
+	/**
+	 * @description
+	 * Republishes the current store state into the storages that hold nothing
+	 * for it – in practice, into the route query.
+	 *
+	 * Persistence is restored only once per app lifetime (see `setupStore`),
+	 * and afterwards the query is written by watchers only, i.e. on change.
+	 * So a registry re-opened with state still in memory (closing a card back to
+	 * it, or reaching it from the menu) used to render filtered data behind a
+	 * bare url, losing filters on reload or on copying the link.
+	 *
+	 * Storages that already hold a value are left untouched, so an explicit query
+	 * always wins over in-memory state.
+	 *
+	 * Sequentially, because every route storage write is a router.replace()
+	 * built on top of the current route query.
+	 */
+	const syncPersistence = async () => {
+		await syncPaginationPersistence();
+		await syncFiltersPersistence();
+		await syncHeadersPersistence();
+	};
+
 	const initialize = async ({
 		parentId: storeParentId,
 	}: {
@@ -294,7 +320,17 @@ export const tableStoreBody = <Entity extends Identifiable>(
 			parentId.value = storeParentId;
 		}
 
+		const isStoreAlreadySetUp = isStoreSetUp.value;
+
 		await setupStore();
+
+		/*
+     on the first setup the restore path is authoritative,
+      so publishing is needed on re-mounts only
+     */
+		if (isStoreAlreadySetUp && !disablePersistence) {
+			await syncPersistence();
+		}
 
 		return loadDataList();
 	};
@@ -329,6 +365,7 @@ export const tableStoreBody = <Entity extends Identifiable>(
 
 		setupStore, // only setup, no data loading
 		initialize, // setup + load data
+		syncPersistence, // republish store state into the route query
 
 		loadDataList,
 		appendToDataList,


### PR DESCRIPTION
[WTEL-10093](https://webitel.atlassian.net/browse/WTEL-10093)

## Problem

Apply filters on a registry → open a card → close it with **"Закрити"** → F5 → filters are gone.

`useClose` pushes the registry route without a query, and registry filters live exactly in `route.query` (`useRoutePersistedStorage`). The pinia store keeps the state in memory, so the list still renders filtered — but the url is bare, so reloading or sharing the link loses everything.

The reason nothing republishes it: `setupStore()` restores persistence **once per app lifetime** (`isStoreSetUp` guard), and afterwards the query is written by watchers only, i.e. on change.

## Solution

The registry publishes its own state back into the query when it is re-mounted, instead of the card trying to carry the query around. This fixes the close-card path, the menu-click path and any other entry path at once, with no changes to `useClose` call sites.

- `usePersistedStorage` exposes **`sync()`** — publishes the current value into the storages that hold nothing for it. Storages that already hold a value are skipped, so **an explicit route query always wins** over in-memory state.
- `createTableFiltersStore` / `createTablePaginationStore` / `createTableHeadersStore` keep their controllers and expose `syncPersistence()`.
- `createTableStore.initialize()` runs it **on re-mounts only** — on the first setup the restore path stays authoritative, so a first load keeps a clean url.
- Syncs run sequentially: every route write is a `router.replace()` built on top of the current query, so parallel writes would clobber each other.
- Lists **nested in card pages** are excluded: they are initialized with a `parentId`, they share the query param names with the registry stores, and the url they would publish into is the card one. They keep writing on change only (`syncPersistence()` stays available for manual use).
- **Default state is not published.** `restore()` captures the snapshot a freshly created store serializes (nothing has mutated the value at that point), and `sync()` skips a value still equal to it — so an untouched registry stays on a clean `/cases` instead of `/cases?page=1&size=10&fields=...`. This also covers the `"{}"` snapshot of `filters` and `columnWidths` generically.

| registry state | query after closing the card |
| --- | --- |
| untouched | *(none)* |
| filters + page 3 | `?filters={...}&page=3` |
| filters + custom columns | `?filters={...}&fields=name,subject,...` |

### Drive-by fixes

**Concurrent route writes dropped each other.** Every write is a `router.replace()` built on top of the current query, and the query only changes once the navigation resolves — so writes issued in the same tick all started from the same snapshot and the last one won. A table store does exactly that: sorting a column makes both `sort` and `fields` emit, and `sort` never reached the url. Route writes are now queued process-wide. Found while writing the store specs; `useRoutePersistedStorage.spec.ts` covers it.


The default restore path picked the first value that was not **strictly** `null`. `useRoutePersistedStorage.getItem` resolves `undefined` for a missing query param, so any storage listed after the route one (e.g. localStorage) could never win. Now a loose `!= null`, matching the `onRestore` branch.

### Why not `router.back()`

Considered and rejected: card tabs navigate with `router.push` (`useCardTabs`), so `back()` from an open card lands on the previous **tab**; cards are also deep-linkable / openable in a new tab, and card→card jumps make it unpredictable. `close()` should stay a deterministic "go to this registry".

## Testing

New specs for every touched module (67 tests in `ui-datalist`, up from 13):

- `persist/__tests__/usePersistedStorage.spec.ts` — `sync()` (publishes into an empty storage, skips an occupied one, skips default and empty values, uses `onStore` serialization, starts no watcher), `restore()` priority and the `!= null` fix, the `watch` path (writes on change, `startWatchManually`, `unwatch`) and `reset()`.
- `persist/__tests__/useRoutePersistedStorage.spec.ts` — reads/writes/removes keeping the rest of the query, stays on the current route, adds no history entry, and the concurrent-write regression.
- `persist/__tests__/useLocalStoragePersistedStorage.spec.ts` — `storagePath` namespacing, array joining, removal.
- `pagination|filters|headers/__tests__/*.spec.ts` — the store bodies' basics plus their restore / write / `syncPersistence` behaviour, driven through a real memory-history router.
- Full suite: 415 passed / 3 skipped. `vue-tsc --noEmit` and `biome check ./src` clean.

Manual pass still needed in CRM: filters + page + sort → open a case → close → query restored → F5 keeps filters; and a link pasted with a different `filters=` must win over in-memory state.

## Known follow-up (not in this PR)

Persist watchers are never stopped and write to the **current** route. If a registry store's filters mutate while a card page is open, `filters=` lands in the card url. Deserves its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[WTEL-10093]: https://webitel.atlassian.net/browse/WTEL-10093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ