### PR TITLE
feat(ui-datalist): drop table columns the user has no access to [WTEL-8093]

### DIFF
--- a/packages/ui-datalist/src/modules/headers/__tests__/createTableHeadersStore.spec.ts
+++ b/packages/ui-datalist/src/modules/headers/__tests__/createTableHeadersStore.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createApp } from 'vue';
+import { createApp, ref } from 'vue';
 import { createMemoryHistory, createRouter, type Router } from 'vue-router';
 
 import type { DatalistTableHeader } from '../../types/tableStore.types';
@@ -138,6 +138,149 @@ describe('tableHeadersStoreBody', () => {
 			await flushWrites();
 
 			expect(router.currentRoute.value.query.sort).toBe('+name');
+		});
+	});
+
+	describe('access', () => {
+		const createGatedStore = (gated: DatalistTableHeader[]) =>
+			tableHeadersStoreBody({
+				rawHeaders: [
+					...rawHeaders.map((header) => ({
+						...header,
+					})),
+					...gated,
+				],
+				id,
+			});
+
+		it('drops a denied header from headers, shownHeaders and fields', () => {
+			const store = createGatedStore([
+				{
+					field: 'agent',
+					show: true,
+					sort: null,
+					access: () => false,
+				} as DatalistTableHeader,
+			]);
+
+			expect(store.headers.value.map(({ field }) => field)).not.toContain(
+				'agent',
+			);
+			expect(store.shownHeaders.value.map(({ field }) => field)).not.toContain(
+				'agent',
+			);
+			expect(store.fields.value).not.toContain('agent');
+		});
+
+		it('keeps a granted header and leaves ungated headers untouched', () => {
+			const store = createGatedStore([
+				{
+					field: 'agent',
+					show: true,
+					sort: null,
+					access: () => true,
+				} as DatalistTableHeader,
+			]);
+
+			expect(store.fields.value).toEqual([
+				'name',
+				'subject',
+				'agent',
+			]);
+		});
+
+		it('unwraps a ref returned by the access gate', () => {
+			const store = createGatedStore([
+				{
+					field: 'agent',
+					show: true,
+					sort: null,
+					access: () => ref(false),
+				} as DatalistTableHeader,
+			]);
+
+			expect(store.fields.value).toEqual([
+				'name',
+				'subject',
+			]);
+		});
+
+		it('does not resurrect a denied header from the persisted fields', async () => {
+			await router.push({
+				name: 'cases',
+				query: {
+					fields: 'agent,createdAt',
+				},
+			});
+
+			const store = createGatedStore([
+				{
+					field: 'agent',
+					show: true,
+					sort: null,
+					access: () => false,
+				} as DatalistTableHeader,
+			]);
+			await runWithRouter(() => store.setupPersistence());
+
+			expect(store.fields.value).toEqual([
+				'createdAt',
+			]);
+			expect(store.headers.value.map(({ field }) => field)).not.toContain(
+				'agent',
+			);
+		});
+
+		it('does not resurrect a denied header on reset', () => {
+			const store = createGatedStore([
+				{
+					field: 'agent',
+					show: true,
+					sort: null,
+					access: () => false,
+				} as DatalistTableHeader,
+			]);
+
+			store.$reset();
+
+			expect(store.headers.value.map(({ field }) => field)).not.toContain(
+				'agent',
+			);
+		});
+
+		it('keeps a field alive while another allowed header still claims it', async () => {
+			await router.push({
+				name: 'cases',
+				query: {
+					fields: 'member',
+				},
+			});
+
+			/* `member` and `memberId` share one API field — only one is gated */
+			const store = createGatedStore([
+				{
+					value: 'member',
+					field: 'member',
+					show: true,
+					sort: null,
+				} as DatalistTableHeader,
+				{
+					value: 'memberId',
+					field: 'member',
+					show: false,
+					sort: null,
+					access: () => false,
+				} as DatalistTableHeader,
+			]);
+			await runWithRouter(() => store.setupPersistence());
+
+			expect(store.headers.value.map(({ value }) => value)).toContain('member');
+			expect(store.headers.value.map(({ value }) => value)).not.toContain(
+				'memberId',
+			);
+			expect(store.fields.value).toEqual([
+				'member',
+			]);
 		});
 	});
 

--- a/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
+++ b/packages/ui-datalist/src/modules/headers/createTableHeadersStore.ts
@@ -1,7 +1,7 @@
 import type { WtTableSortOrder } from '@webitel/ui-sdk/components/wt-table/types/WtTable';
 import { sortToQueryAdapter } from '@webitel/ui-sdk/scripts';
 import { SortSymbols } from '@webitel/ui-sdk/scripts/sortQueryAdapters';
-import { computed, nextTick, ref } from 'vue';
+import { computed, nextTick, ref, unref } from 'vue';
 
 import { createDatalistStore } from '../_shared/createDatalistStore';
 import {
@@ -24,7 +24,21 @@ export const tableHeadersStoreBody = ({
 	rawHeaders,
 	id,
 }: TableHeadersStoreBodyParams) => {
-	const headers = ref<DatalistTableHeader[]>(rawHeaders);
+	const isAllowed = (header: DatalistTableHeader) =>
+		!header.access || !!unref(header.access());
+
+	const allowedHeaders = rawHeaders.filter(isAllowed);
+
+	/* headers may share a `field`, so it stays allowed while any of them is */
+	const allowedFields = new Set(allowedHeaders.map((header) => header.field));
+	const deniedFields = new Set(
+		rawHeaders
+			.filter((header) => !isAllowed(header))
+			.map((header) => header.field)
+			.filter((field) => !allowedFields.has(field)),
+	);
+
+	const headers = ref<DatalistTableHeader[]>(allowedHeaders);
 	const isReorderingColumn = ref(false);
 
 	const shownHeaders = computed(() => {
@@ -64,7 +78,7 @@ export const tableHeadersStoreBody = ({
 	});
 
 	const $reset = () => {
-		headers.value = rawHeaders;
+		headers.value = allowedHeaders;
 	};
 
 	const updateShownHeaders = (value: DatalistTableHeader[]) => {
@@ -112,7 +126,10 @@ export const tableHeadersStoreBody = ({
 		});
 	};
 
-	const updateFields = (fields: string[]) => {
+	const updateFields = (persistedFields: string[]) => {
+		/* persisted state predates the gate, and unknown fields are revived below */
+		const fields = persistedFields.filter((field) => !deniedFields.has(field));
+
 		const fieldsSet = new Set(fields);
 		const mainFieldNames = new Set(headers.value.map((header) => header.field));
 

--- a/packages/ui-datalist/src/modules/types/tableStore.types.ts
+++ b/packages/ui-datalist/src/modules/types/tableStore.types.ts
@@ -13,6 +13,13 @@ import type { DatalistStoreProviderType } from './StoreProvider';
 export type DatalistTableHeader = WtTableHeader & {
 	field: string;
 	shouldBeInitialized?: boolean;
+	/**
+	 * Access gate supplied by the consuming app, evaluated once when the headers
+	 * store is created. Returning `false` drops the column completely: absent
+	 * from the column picker, never rendered, never requested, and not
+	 * restorable from persisted state. Omitted means allowed.
+	 */
+	access?: () => boolean | Ref<boolean>;
 };
 
 export type TrackSelectedRowBy<T> = (row: T) => T;


### PR DESCRIPTION
[WTEL-8093](https://webitel.atlassian.net/browse/WTEL-8093)

Companion PR: webitel/cc-history#695 — this one must merge and publish first.

## Problem

`header.show` is a user preference, not a permission. There was no way to say "this column is unavailable to this user", so apps could only filter columns at the component level — which still leaves the field in the `fields` request param and still lists it in the column picker.

## Approach

Optional `access` gate on `DatalistTableHeader`, evaluated **once** when the headers store is created:

```ts
{
  value: 'screencast',
  field: 'screencast',
  access: () => useUserinfoStore().hasSpecialGlobalActionAccess(
    SpecialGlobalAction.ControlAgentScreen,
  ),
}
```

Denied headers are **removed** from the `headers` ref rather than flagged `show: false`, so one filter covers every consumer at once:

- column picker (`:headers="headers"`) — not listed
- `shownHeaders` → `wt-table` — not rendered
- `fields` → `getLoadDataParams()` — never requested from the API

The callback is supplied by the app, so the package keeps its zero-runtime-dependency, auth-agnostic design. `boolean` and `Ref<boolean>` are both accepted (resolved with `unref`), so `() => useUserAccessControl(WtObject.Agent).hasReadAccess` works too.

Evaluating once keeps every existing mutation path (`updateSort`, `updateShownHeaders`, `columnResize`, `columnReorder`, `$reset`) working unchanged — no merge-back logic for hidden entries. Access data is fetched at app bootstrap and does not change in-session.

## Two resurrection paths closed

1. **`updateFields()`** — the persistence-restore path revives any field it doesn't recognise as a `shouldBeInitialized` placeholder with `show: true`. A stale `?fields=screencast` in the URL, or a leftover `localStorage["<ns>/headers/fields"]`, would bring a denied column straight back *and* send it to the API. Now filtered against a `deniedFields` set.
2. **`$reset()`** — re-assigned the unfiltered `rawHeaders` by reference.

Headers may share one `field` (`member` and `memberId` both map to `member`), so a field only counts as denied while no allowed header still claims it.

## Test plan

- `packages/ui-datalist` suite: **74 passed / 9 files**, including 6 new `access` cases — denied column dropped from `headers`/`shownHeaders`/`fields`; granted and ungated headers unaffected; `Ref` form unwrapped; no resurrection from a route query; no resurrection on `$reset()`; shared-`field` case does not suppress the allowed header.
- `npm run typecheck` clean.
- Behaviour is unchanged for every existing header — `access` is optional and no current consumer sets it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WTEL-8093]: https://webitel.atlassian.net/browse/WTEL-8093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ